### PR TITLE
Handle closed connections in host controller

### DIFF
--- a/host_eloquence32.py
+++ b/host_eloquence32.py
@@ -294,7 +294,11 @@ class HostController:
     def serve_forever(self) -> None:
         LOGGER.info("Host controller waiting for commands")
         while True:
-            message = self._conn.recv()
+            try:
+                message = self._conn.recv()
+            except (EOFError, ConnectionError, OSError) as exc:
+                LOGGER.info("Connection closed, stopping host controller: %s", exc)
+                break
             if not isinstance(message, dict):
                 LOGGER.warning("Unexpected message %r", message)
                 continue


### PR DESCRIPTION
## Summary
- add defensive handling for closed connections in the host controller loop
- stop the host controller cleanly when the client disconnects

## Testing
- python -m compileall host_eloquence32.py

------
https://chatgpt.com/codex/tasks/task_e_68ee731c63a48330a979c36bf692f820