### PR TITLE
Queue Eloquence index callbacks on NVDA event thread

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -17,6 +17,10 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 import config
 import nvwave
+try:
+    import queueHandler
+except ImportError:
+    queueHandler = None
 from buildVersion import version_year
 
 LOGGER = logging.getLogger(__name__)
@@ -120,7 +124,10 @@ class AudioWorker(threading.Thread):
     def _invoke_index_callback(self, value: Optional[int]) -> None:
         if onIndexReached:
             try:
-                onIndexReached(value)
+                if queueHandler is not None:
+                    queueHandler.queueFunction(queueHandler.eventQueue, onIndexReached, value)
+                else:
+                    onIndexReached(value)
             except Exception:
                 LOGGER.exception("Index callback failed")
 


### PR DESCRIPTION
## Summary
- queue Eloquence index callback invocations via NVDA's event queue to avoid crashes and missed events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eed1e7ef6883309dfce0ef7251e84b