### PR TITLE
Fix Eloquence index callbacks firing delay

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -107,21 +107,14 @@ class AudioWorker(threading.Thread):
                 break
             data, index, is_final = chunk
             self._prepare_for_chunk(is_final)
+            if index is not None:
+                self._invoke_index_callback(index)
             if not data:
-                if index is not None:
-                    self._invoke_index_callback(index)
                 if is_final:
                     self._emit_final()
                 self._queue.task_done()
                 continue
-            on_done = None
-            if index is not None:
-
-                def _callback(i=index):
-                    self._invoke_index_callback(i)
-
-                on_done = _callback
-            wrapped_on_done = self._make_on_done(on_done, is_final)
+            wrapped_on_done = self._make_on_done(None, is_final)
             tries = 0
             fed = False
             while tries < 10:


### PR DESCRIPTION
## Summary
- call Eloquence index callbacks as soon as the host reports an index so say all can continue reading subsequent fragments

## Testing
- python -m compileall _eloquence.py

------
https://chatgpt.com/codex/tasks/task_e_68eeee3c4794833094e546f9cfec8d36