### PR TITLE
Dispatch index callbacks immediately when audio chunks arrive

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -61,11 +61,10 @@ class AudioWorker(threading.Thread):
                 continue
             on_done = None
             if index is not None:
-
-                def _callback(i=index):
-                    self._invoke_index_callback(i)
-
-                on_done = _callback
+                # Dispatch index notifications immediately so NVDA's say-all
+                # controller can enqueue subsequent text fragments without
+                # waiting for audio playback to finish.
+                self._invoke_index_callback(index)
             wrapped_on_done = self._make_on_done(on_done, is_final)
             tries = 0
             fed = False


### PR DESCRIPTION
## Summary
- dispatch index callbacks as soon as audio chunks are processed so say-all can continue queuing text
- document the immediate dispatch behavior in the audio worker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef904673408330a9bb363b697c47b1