### PR TITLE
fix: use default WavePlayer ducking behavior

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -176,8 +176,7 @@ class EloquenceHostClient:
             return
         if version_year >= 2025:
             device = config.conf["audio"]["outputDevice"]
-            ducking = True if config.conf["audio"]["audioDuckingMode"] else False
-            player = nvwave.WavePlayer(1, 11025, 16, outputDevice=device, wantDucking=ducking)
+            player = nvwave.WavePlayer(1, 11025, 16, outputDevice=device)
         else:
             device = config.conf["speech"]["outputDevice"]
             nvwave.WavePlayer.MIN_BUFFER_MS = 1500


### PR DESCRIPTION
## Summary

Fixes #32 by removing the explicit `wantDucking` parameter conversion that was causing audio ducking modes to behave inconsistently.

## Root Cause

The add-on was explicitly converting the audio ducking mode (0/1/2) to a boolean and passing it to `WavePlayer`:

```python
ducking = True if config.conf["audio"]["audioDuckingMode"] else False
player = nvwave.WavePlayer(1, 11025, 16, outputDevice=device, wantDucking=ducking)
```

This caused timing-dependent behavior because:

1. `speech.initialize()` (which loads synth drivers) runs before `audioDucking.initialize()` 
2. The global `_audioDuckingMode` starts at 0 (NONE) until `audioDucking.initialize()` sets it via `wx.CallAfter`
3. Early speech utterances could occur before the mode was properly configured
4. Eloquence was the only synth explicitly passing this parameter - all others (eSpeak, OneCore, SAPI5) use the default

## Solution

Use the default `wantDucking=True` parameter, just like all other NVDA synth drivers. This allows the global `audioDucking` module to properly control ducking behavior based on the user's configured mode, eliminating the initialization order dependency.

## Testing

- "Always duck" mode should continue to work as before
- "Duck when outputting speech and sounds" mode should now properly duck only during speech output
- "No ducking" mode should continue to work correctly

The global audio ducking module handles all mode logic, so the synth driver just needs to ensure an `AudioDucker` is available when needed.