### PR TITLE
Restore dash pauses and improve punctuation robustness

### DIFF
--- a/eloquence.py
+++ b/eloquence.py
@@ -47,7 +47,7 @@ log = logging.getLogger(__name__)
 
 minRate=40
 maxRate=150
-pause_re = re.compile(r'([a-zA-Z])([.(),:;!?])( |$)')
+pause_re = re.compile(r'([a-zA-Z0-9])([.(),:;!?\-])( |$)')
 time_re = re.compile(r"(\d):(\d+):(\d+)")
 english_fixes = {
     re.compile(r'(\w+)\.([a-zA-Z]+)'): r'\1 dot \2',
@@ -373,8 +373,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         _eloquence.process()
 
     def xspeakText(self,text, should_pause=False):
-        # Presumably dashes are handled as symbols by NVDA symbol processing, so strip extra ones to avoid too many dashes.
-        text = text.replace("-", " ")
         if _eloquence.params[9] == 65536 or _eloquence.params[9] == 65537: text = resub(english_fixes, text)
         if _eloquence.params[9] == 131072 or _eloquence.params[9] == 131073: text = resub(spanish_fixes, text)
         if _eloquence.params[9] in (196609, 196608): text = resub(french_fixes, text)


### PR DESCRIPTION
This PR restores missing speech pauses for dashes and improves the overall robustness of punctuation handling in the 64-bit version.

### Key Improvements

1. **Restored Dash Pauses:** Removed the `text.replace("-", " ")` logic which was stripping dashes before the engine could process them.
2. **Enhanced Regex Robustness:** Updated `pause_re` from `([a-zA-Z])` to `([a-zA-Z0-9])`. This ensures that punctuation following a number (e.g., "In 2026-") now correctly triggers a prosodic pause.
3. **Punctuation Support:** Added the dash (`\-`) to the regex character set to force a manual Eloquence pause command (`` `p1 ``) where the engine might otherwise ignore it in the 64-bit RPC stream.

### Result

Speech sounds more natural and follows the expected rhythm, especially in technical text or lists containing numbers and dashes.

### Compatibility with NVDA Symbol Settings:

This fix enables proper prosody when the dash symbol in NVDA's "Symbol pronunciation" is configured to "Send actual symbol to synthesizer only below symbol's level." This resolves the "double dash" stutter encountered when the setting is set to "Always," while ensuring that natural pauses are restored when NVDA is not explicitly announcing the punctuation.