### PR TITLE
Fix pause for dashes again

### DIFF
--- a/eloquence.py
+++ b/eloquence.py
@@ -964,7 +964,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         _eloquence.process()
 
     def xspeakText(self, text, should_pause=False):
-        text = text.replace("-", " ")
         if _eloquence.params[9] == 65536 or _eloquence.params[9] == 65537:
             text = resub(english_fixes, text)
         if _eloquence.params[9] == 131072 or _eloquence.params[9] == 131073:


### PR DESCRIPTION
Somehow a single line snuck back in that killed pausing for dashes.

In the xspeakText function, the line under the function definition was the culprit.
```
text = text.replace("-", " ")
```

This line was effectively turning the dash into a space before it could get to the synthesizer.