### PR TITLE
Fix rate state leak between utterances

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -372,6 +372,15 @@ rgh = 4
 bth = 5
 rate = 6
 vlm = 7
+PARAM_MAX = {
+    rate: 250,
+    pitch: 100,
+    vlm: 100,
+    hsz: 100,
+    fluctuation: 100,
+    rgh: 100,
+    bth: 100,
+}
 eciPath = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "eloquence", "eci.dll")
 )
@@ -462,8 +471,8 @@ def cmdProsody(pr, multiplier, offset=0):
     """
     base = getVParam(pr)
     value = int(base * multiplier + offset)
-    # Clamp to valid ECI parameter range (0-100).
-    value = max(0, min(value, 100))
+    # Clamp to valid ECI parameter range.
+    value = max(0, min(value, PARAM_MAX.get(pr, 100)))
     setVParam(pr, value, temporary=True)
 
 

--- a/eloquence.py
+++ b/eloquence.py
@@ -852,6 +852,11 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         pending_indexes = []
         queued_speech = False
 
+        # Reset prosody to baseline at the start of each utterance to prevent
+        # state leaks from previous speech sequences (issue #59).
+        for pr in (_eloquence.rate, _eloquence.pitch, _eloquence.vlm):
+            outlist.append((_eloquence.cmdProsody, (pr, 1, 0)))
+
         # IBMTTS Logic: Combine strings before processing regex
         speechSequence = self.combine_adjacent_strings(speechSequence)
 


### PR DESCRIPTION
## Summary

Fixes #59 — temporary `RateCommand` prosody changes (e.g., typing echo at a higher rate) leak into subsequent utterances.

Two bugs contribute to the leak:

- **Clamping bug:** `cmdProsody` clamped all parameters to 0–100, but the Eloquence rate range is 0–250. For users with NVDA rate above ~55%, the "restore" command silently set the DLL rate to 100 instead of the correct baseline. Fixed by using per-parameter upper bounds (`PARAM_MAX` dict).
- **Missing baseline reset:** `speak()` began synthesis with whatever DLL rate/pitch/volume was left by the previous utterance, so any corruption persisted indefinitely. Fixed by prepending prosody resets (`cmdProsody(pr, 1, 0)` → base × 1 + 0 = base) at the start of every `speak()` call.

## Changes

- `_eloquence.py`: Add `PARAM_MAX` dictionary; update clamp in `cmdProsody` to use per-parameter bounds
- `eloquence.py`: Prepend prosody baseline reset at the start of `speak()`

## Request for testers

I was unable to reproduce the original bug, so **this PR needs testing from users who can trigger the issue** before merging. Please test the following scenarios and report results:

### Testing steps

1. **Install the add-on** from this branch (build attached or build with `build.cmd`)
2. **Set NVDA rate above 55%** (this is where the clamping bug kicks in)
3. **Typing echo test:** Enable typing echo, type several characters quickly, then navigate away — verify the next spoken utterance returns to the correct rate (not stuck fast or slow)
4. **Caps pitch test:** Type some UPPERCASE text (which triggers `PitchCommand`), then type lowercase — verify pitch returns to normal
5. **Start Menu search test:** Open Start Menu, type a search query rapidly, then arrow through results — verify result announcements use the correct rate, not a leaked faster/slower rate
6. **Rate slider test:** Move the NVDA rate slider to various positions (low, mid, high) and verify speech sounds correct at each setting with no unexpected jumps at utterance boundaries
7. **sayAll test:** Use sayAll (NVDA+Down Arrow) on a long document — verify consistent rate throughout

### What to look for

- Rate should never "stick" at a different speed after typing echo or caps
- No audible rate glitches at the start of utterances
- Normal speech at all rate slider positions should sound identical to before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)