### PR TITLE
Settings panel now correctly displayed

### DIFF
--- a/eloquence.py
+++ b/eloquence.py
@@ -186,7 +186,7 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 
     def makeSettings(self, settings):
         try:
-            sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
+            sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settings)
 
             self.dictionarySources = {
                 "https://github.com/mohamed00/AltIBMTTSDictionaries": "Alternative IBM TTS Dictionaries",


### PR DESCRIPTION
Although working for a blind person, Eloquence settings panel controls were not visible on the Eloquence settings panel.

With this PR, the controls of the settings panel are now normally visible.
