### PR TITLE
Add Spanish translation

### DIFF
--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -1,0 +1,438 @@
+# Translation of Eloquence add-on for NVDA.
+# Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Eloquence package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Eloquence\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-02 16:18+0100\n"
+"PO-Revision-Date: 2026-03-05 12:00-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.8\n"
+"X-Poedit-Flags-xgettext: --add-comments=Translators:\n"
+"X-Poedit-Basepath: ../../../..\n"
+"X-Poedit-SearchPath-0: .\n"
+
+#. Translators: Name of the category for this add-on in the settings dialog
+#. Translators: Title of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:127 addon\synthDrivers\eloquence.py:686
+msgid "Eloquence"
+msgstr "Eloquence"
+
+#. Translators: Label of a combobox in the Eloquence category of the settings dialog
+#: addon\synthDrivers\eloquence.py:140
+msgid "Dictionary:"
+msgstr "Diccionario:"
+
+#: addon\synthDrivers\eloquence.py:146
+msgid "Check for updates"
+msgstr "Buscar actualizaciones"
+
+#. Translators: Label of a button in the Eloquence category of the settings dialog
+#: addon\synthDrivers\eloquence.py:155
+msgid "Copy Helper to System Config (for Logon Screen)"
+msgstr ""
+"Copiar Helper a la configuración del sistema (para la pantalla de inicio de "
+"sesión)"
+
+#. Translators: Label of a button in the Eloquence category of the settings dialog
+#: addon\synthDrivers\eloquence.py:166
+msgid "Check for Add-on Updates"
+msgstr "Buscar actualizaciones del complemento"
+
+#. Translators: Text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:188
+msgid ""
+"Eloquence folder not found in systemConfig.\n"
+"\n"
+"Please go to NVDA Settings > General and click 'Use currently saved settings "
+"during sign-in' first to initialize folders."
+msgstr ""
+"Carpeta de Eloquence no encontrada en systemConfig.\n"
+"\n"
+"Por favor, vaya a Configuración de NVDA > General y haga clic en 'Usar la "
+"configuración guardada en el inicio de sesión' primero para inicializar las "
+"carpetas."
+
+#. Translators: Title of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:191
+msgid "Folder Missing"
+msgstr "Carpeta no encontrada"
+
+#. Translators: Text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:202
+#, python-brace-format
+msgid ""
+"Source file not found at:\n"
+"{source_file}"
+msgstr ""
+"Archivo de origen no encontrado en:\n"
+"{source_file}"
+
+#. Translators: Title of a message dialog when copying the helper to system config
+#. Translators: Title of a message dialog when updating the add-on
+#. Translators: Title of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:204 addon\synthDrivers\eloquence.py:242
+#: addon\synthDrivers\eloquence.py:250 addon\synthDrivers\eloquence.py:269
+#: addon\synthDrivers\eloquence.py:283 addon\synthDrivers\eloquence.py:467
+#: addon\synthDrivers\eloquence.py:695
+msgid "Error"
+msgstr "Error"
+
+#. Translators: text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:222
+msgid ""
+"Successfully copied eloquence_host32.exe to systemConfig!\n"
+"\n"
+"Eloquence should now load normally on logon screen, start-up, and other "
+"secure screens."
+msgstr ""
+"¡eloquence_host32.exe se copió correctamente a systemConfig!\n"
+"\n"
+"Eloquence debería cargarse normalmente en la pantalla de inicio de sesión, "
+"el arranque y otras pantallas seguras."
+
+#. Translators: Title of a message dialog when copying the helper to system config
+#. Translators: Title of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:225 addon\synthDrivers\eloquence.py:678
+msgid "Success"
+msgstr "Éxito"
+
+#. Translators: Text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:232
+msgid "Copy process was cancelled or permission was denied by the user."
+msgstr "El proceso de copia fue cancelado o el permiso fue denegado por el usuario."
+
+#. Translators: Title of a message dialog when copying the helper to system config
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:234 addon\synthDrivers\eloquence.py:393
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. Translators: Text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:240
+#, python-brace-format
+msgid ""
+"An error occurred while attempting to copy the file. (Error Code: {ret})"
+msgstr ""
+"Ocurrió un error al intentar copiar el archivo. (Código de error: {ret})"
+
+#. Translators: Text of a message dialog when copying the helper to system config
+#: addon\synthDrivers\eloquence.py:248
+#, python-brace-format
+msgid "An unexpected error occurred: {e}"
+msgstr "Ocurrió un error inesperado: {e}"
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:267
+msgid "Update manager not found. Please reinstall the add-on."
+msgstr ""
+"Gestor de actualizaciones no encontrado. Por favor, reinstale el complemento."
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:281
+#, python-brace-format
+msgid "Failed to load update manager: {e}"
+msgstr "Error al cargar el gestor de actualizaciones: {e}"
+
+#. Translators: Title of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:294
+msgid "Checking for Updates"
+msgstr "Buscando actualizaciones"
+
+#. Translators: Message of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:296
+msgid "Connecting to GitHub..."
+msgstr "Conectando a GitHub..."
+
+#. Translators: Message of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:308
+msgid "Checking for updates..."
+msgstr "Buscando actualizaciones..."
+
+#. Translators: Message of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:318
+msgid "No updates available"
+msgstr "No hay actualizaciones disponibles"
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:322
+msgid "You are using the latest version!"
+msgstr "¡Está utilizando la última versión!"
+
+#. Translators: Title of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:324
+msgid "Up to Date"
+msgstr "Actualizado"
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:331
+msgid "Update available!"
+msgstr "¡Actualización disponible!"
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:338
+#, python-brace-format
+msgid ""
+"New version available: {latest_version}\n"
+"\n"
+"Current version: {currVersion}\n"
+"\n"
+"Changelog:\n"
+"{changelog}\n"
+"\n"
+"Would you like to download and review the update?"
+msgstr ""
+"Nueva versión disponible: {latest_version}\n"
+"\n"
+"Versión actual: {currVersion}\n"
+"\n"
+"Registro de cambios:\n"
+"{changelog}\n"
+"\n"
+"¿Desea descargar y revisar la actualización?"
+
+#. Translators: Title of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:348
+msgid "Update Available"
+msgstr "Actualización disponible"
+
+#. Translators: Text of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:358
+msgid "Downloading Update"
+msgstr "Descargando actualización"
+
+#. Translators: Title of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:360
+msgid "Downloading..."
+msgstr "Descargando..."
+
+#. Translators: Text of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:374
+msgid "Extracting update..."
+msgstr "Extrayendo actualización..."
+
+#. Translators: Text of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:379
+msgid "Analyzing changes..."
+msgstr "Analizando cambios..."
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:391
+msgid "Update cancelled."
+msgstr "Actualización cancelada."
+
+#. Translators: Text of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:401
+msgid "Applying Update"
+msgstr "Aplicando actualización"
+
+#. Translators: Text of a progress dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:403
+msgid "Please wait..."
+msgstr "Por favor, espere..."
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:420
+#, python-brace-format
+msgid ""
+"Update to {latest_version} applied successfully!\n"
+"\n"
+"Please restart NVDA for changes to take effect."
+msgstr ""
+"¡La actualización a {latest_version} se aplicó correctamente!\n"
+"\n"
+"Por favor, reinicie NVDA para que los cambios surtan efecto."
+
+#. Translators: Title of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:424
+msgid "Update Successful"
+msgstr "Actualización exitosa"
+
+#. Translators: Text of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:437
+#, python-brace-format
+msgid ""
+"Update failed: {e}\n"
+"\n"
+"Your addon has not been modified."
+msgstr ""
+"Error en la actualización: {e}\n"
+"\n"
+"Su complemento no ha sido modificado."
+
+#. Translators: Title of a message dialog when updating the add-on
+#: addon\synthDrivers\eloquence.py:441
+msgid "Update Failed"
+msgstr "Error en la actualización"
+
+#. Translators: Text of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:465
+msgid "Please select a dictionary first."
+msgstr "Por favor, seleccione un diccionario primero."
+
+#. Translators: Text of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:672
+#, python-brace-format
+msgid ""
+"Dictionary update successful!\n"
+"\n"
+"• Total updates: {updates_count}\n"
+"• Dictionary files: {new_files}\n"
+"\n"
+"Note: CP1252 encoding enforced; some accents may have been stripped for "
+"compatibility."
+msgstr ""
+"¡Actualización del diccionario exitosa!\n"
+"\n"
+"• Total de actualizaciones: {updates_count}\n"
+"• Archivos de diccionario: {new_files}\n"
+"\n"
+"Nota: Se aplicó la codificación CP1252; algunos acentos pueden haberse "
+"eliminado por compatibilidad."
+
+#. Translators: Text of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:684
+msgid "No new updates found. Your dictionaries are already up to date."
+msgstr ""
+"No se encontraron nuevas actualizaciones. Sus diccionarios ya están "
+"actualizados."
+
+#. Translators: Text of a message dialog when updating a dictionary
+#: addon\synthDrivers\eloquence.py:693
+#, python-brace-format
+msgid "An error occurred while updating the dictionary: {e}"
+msgstr "Ocurrió un error al actualizar el diccionario: {e}"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:711
+msgid "Hea&d size"
+msgstr "Tamaño de ca&beza"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:713
+msgid "Rou&ghness"
+msgstr "As&pereza"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:715
+msgid "Breathi&ness"
+msgstr "Res&piración"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:718
+msgid "Enable backquote voice &tags"
+msgstr "Habilitar e&tiquetas de voz con acento grave"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:721
+msgid "Enable &abbreviation dictionary"
+msgstr "Habilitar diccionario de &abreviaturas"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:723
+msgid "Enable phras&e prediction"
+msgstr "Habilitar pr&edicción de frases"
+
+#. Translators: A synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:725
+msgid "&Pauses"
+msgstr "&Pausas"
+
+#. Translators: One of the mode listed in the pause combobox synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:993
+msgid "Do not shorten"
+msgstr "No acortar"
+
+#. Translators: One of the mode listed in the pause combobox synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:995
+msgid "Shorten at end only"
+msgstr "Acortar solo al final"
+
+#. Translators: One of the mode listed in the pause combobox synth setting available in speech settings dialog
+#: addon\synthDrivers\eloquence.py:997
+msgid "Shorten all pauses"
+msgstr "Acortar todas las pausas"
+
+#. Translators: Title of the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:19
+msgid "Review Update Changes"
+msgstr "Revisar cambios de la actualización"
+
+#. Translators: Text in the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:25
+#, python-brace-format
+msgid "Update to version {latest_version} includes the following changes:"
+msgstr ""
+"La actualización a la versión {latest_version} incluye los siguientes "
+"cambios:"
+
+#. Translators: Column header in the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:31
+msgid "Action"
+msgstr "Acción"
+
+#. Translators: Column header in the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:33
+msgid "File"
+msgstr "Archivo"
+
+#: addon\synthDrivers\_eloquence_updater.py:37
+msgid "Add"
+msgstr "Agregar"
+
+#. Translators: Action name used in the list of the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:42
+msgid "Update"
+msgstr "Actualizar"
+
+#. Translators: Action name used in the list of the Review Update Changes dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:47
+msgid "Delete"
+msgstr "Eliminar"
+
+#: addon\synthDrivers\_eloquence_updater.py:57
+#, python-brace-format
+msgid "Note: {n} local configuration/dictionary files will be preserved."
+msgstr ""
+"Nota: se conservarán {n} archivos locales de configuración/diccionario."
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:186
+#, python-brace-format
+msgid "Downloading update... {percent}%"
+msgstr "Descargando actualización... {percent}%"
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:207
+#, python-brace-format
+msgid "Extracting... {percent}%"
+msgstr "Extrayendo... {percent}%"
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:297
+msgid "Analysis complete"
+msgstr "Análisis completado"
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:305
+msgid "No changes to apply"
+msgstr "No hay cambios que aplicar"
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:314
+#, python-brace-format
+msgid "Applying: {path}"
+msgstr "Aplicando: {path}"
+
+#. Translators: Text in the progress dialog used during add-on update.
+#: addon\synthDrivers\_eloquence_updater.py:336
+msgid "Update complete"
+msgstr "Actualización completada"


### PR DESCRIPTION
Added complete Spanish (es) translation for the Eloquence NVDA addon.

- 65 translated message entries covering settings dialog, update manager, synth settings, and pause modes
- Validated with msgfmt --check (zero errors)
- Follows the same .po format as existing French and German translations