### PR TITLE
Auto-copy _multiprocessing.pyd during build and install

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -20,6 +20,30 @@ env.Append(**buildVars.addon_info)
 
 addonDir = Path("addon")
 
+# --- Auto-copy _multiprocessing.pyd from system Python --------------------
+
+_mp_eci_dir = addonDir / "synthDrivers" / "eloquence"
+_mp_dest = _mp_eci_dir / "_multiprocessing.pyd"
+if not _mp_dest.exists():
+	import sysconfig, shutil
+	_dlls_dir = Path(sysconfig.get_paths()["platlib"]).parent / "DLLs"
+	_mp_src = _dlls_dir / "_multiprocessing.pyd"
+	if not _mp_src.exists():
+		# Fallback: try stdlib path
+		_dlls_dir = Path(sysconfig.get_paths()["stdlib"]).parent / "DLLs"
+		_mp_src = _dlls_dir / "_multiprocessing.pyd"
+	if _mp_src.exists():
+		shutil.copy2(str(_mp_src), str(_mp_dest))
+		print(f"Copied _multiprocessing.pyd from {_mp_src}")
+	else:
+		print(
+			"ERROR: _multiprocessing.pyd not found in Python's DLLs directory.\n"
+			f"Searched: {_dlls_dir}\n"
+			"Ensure you are running with a CPython installation that includes this extension.",
+			file=sys.stderr,
+		)
+		Exit(1)
+
 # --- Compile translations (.po -> .mo) -------------------------------------
 
 import glob

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def onInstall():
+	"""Copy _multiprocessing.pyd into the addon if missing.
+
+	NVDA's frozen Python does not expose the _multiprocessing C extension,
+	so the addon bundles its own copy.  The build system (SConstruct) normally
+	places it, but this hook acts as a safety net when the addon is installed
+	from a pre-built .nvda-addon package.
+	"""
+	addon_dir = Path(__file__).parent
+	dest = addon_dir / "synthDrivers" / "eloquence" / "_multiprocessing.pyd"
+	if dest.exists():
+		return
+
+	# Try to locate _multiprocessing.pyd from a system Python installation.
+	candidates = []
+
+	# 1. sysconfig (works when a full CPython is installed)
+	try:
+		import sysconfig
+
+		dll_dir = Path(sysconfig.get_path("platlib")).parent / "DLLs"
+		candidates.append(dll_dir / "_multiprocessing.pyd")
+		# Fallback: stdlib-based path
+		dll_dir2 = Path(sysconfig.get_path("stdlib")).parent / "DLLs"
+		candidates.append(dll_dir2 / "_multiprocessing.pyd")
+	except Exception:
+		pass
+
+	# 2. Common default install locations
+	for ver in ("313", "312", "311"):
+		candidates.append(Path(f"C:\\Python{ver}\\DLLs\\_multiprocessing.pyd"))
+		candidates.append(
+			Path(
+				os.path.expandvars(
+					f"%LOCALAPPDATA%\\Programs\\Python\\Python{ver}\\DLLs\\_multiprocessing.pyd"
+				)
+			)
+		)
+
+	for src in candidates:
+		if src.exists():
+			shutil.copy2(str(src), str(dest))
+			return


### PR DESCRIPTION
Automatically copies _multiprocessing.pyd from the system Python installation if missing.

- SConstruct: copies the file before compilation begins, using sysconfig for portable path resolution
- installTasks.py: new onInstall() hook copies the file when the .nvda-addon is installed by NVDA
- If the file already exists, nothing happens
- Prevents the ModuleNotFoundError that occurs when _multiprocessing.pyd is missing