### PR TITLE
Fix audio output not following NVDA device changes

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -224,6 +224,19 @@ class EloquenceHostClient:
 		self._audio_worker.start()
 
 	# ------------------------------------------------------------------
+	def close_audio(self) -> None:
+		if self._audio_worker:
+			self._audio_worker.stop()
+			self._audio_worker.join(timeout=1)
+			self._audio_worker = None
+		if self._player:
+			try:
+				self._player.close()
+			except Exception:
+				LOGGER.exception("WavePlayer close failed")
+			self._player = None
+
+	# ------------------------------------------------------------------
 	def _receiver_loop(self) -> None:
 		connection = self._host.connection if self._host else None
 		if connection is None:
@@ -504,6 +517,10 @@ def stop():
 def pause(switch):
 	if _client._player:
 		_client._player.pause(switch)
+
+
+def close_audio():
+	_client.close_audio()
 
 
 def terminate():

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -795,6 +795,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			raise
 
 	def terminate(self):
+		_eloquence.close_audio()
 		# Safe settings panel removal - won't crash if it was never registered
 		try:
 			if hasattr(gui.settingsDialogs, "NVDASettingsDialog"):


### PR DESCRIPTION
## Summary

- Adds `close_audio()` to tear down the `WavePlayer` and audio worker without killing the 32-bit host process
- Calls `close_audio()` from `SynthDriver.terminate()` so a fresh player is created on re-initialization with the correct output device
- The host process stays alive, avoiding unnecessary DLL reload latency on device switches

Closes #58

## Test plan

- [ ] Connect a secondary audio device (e.g. Bluetooth headphones)
- [ ] In NVDA settings, switch audio output to the secondary device — verify speech comes from it
- [ ] Switch audio output back to the default device — verify speech follows immediately
- [ ] Repeat several times to confirm stability
- [ ] Verify normal speech synthesis still works after multiple switches