### PR TITLE
Rename Pauses combo box labels for clarity

### DIFF
--- a/addon/locale/de/LC_MESSAGES/nvda.po
+++ b/addon/locale/de/LC_MESSAGES/nvda.po
@@ -343,7 +343,7 @@ msgstr "&Satzvorhersage einschalten"
 
 #. Translators: A synth setting available in speech settings dialog
 #: addon\synthDrivers\eloquence.py:725
-msgid "&Shorten pauses"
+msgid "Shorten &pauses"
 msgstr "&Pausen kürzen"
 
 #. Translators: An option in the "Shorten pauses" combo box in speech settings

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -343,8 +343,8 @@ msgstr "Habilitar pr&edicción de frases"
 
 #. Translators: A synth setting available in speech settings dialog
 #: addon\synthDrivers\eloquence.py:725
-msgid "&Shorten pauses"
-msgstr "&Acortar pausas"
+msgid "Shorten &pauses"
+msgstr "Acortar &pausas"
 
 #. Translators: An option in the "Shorten pauses" combo box in speech settings
 #: addon\synthDrivers\eloquence.py:993

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -345,8 +345,8 @@ msgstr "Activer la prédiction de phras&e"
 
 #. Translators: A synth setting available in speech settings dialog
 #: addon\synthDrivers\eloquence.py:725
-msgid "&Shorten pauses"
-msgstr "&Raccourcir les pauses"
+msgid "Shorten &pauses"
+msgstr "Raccourcir les &pauses"
 
 #. Translators: An option in the "Shorten pauses" combo box in speech settings
 #: addon\synthDrivers\eloquence.py:993

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -726,7 +726,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		# Translators: A synth setting available in speech settings dialog
 		BooleanDriverSetting("phrasePrediction", _("Enable phras&e prediction"), False),
 		# Translators: A synth setting available in speech settings dialog
-		DriverSetting("pauseMode", _("&Shorten pauses"), defaultVal="0"),
+		DriverSetting("pauseMode", _("Shorten &pauses"), defaultVal="0"),
 	)
 	supportedCommands = {
 		IndexCommand,


### PR DESCRIPTION
## Summary

Closes #81.

- Rename the combo box label from "Pauses" to "Shorten pauses" so its purpose is clear without needing to read the item labels
- Simplify combo box items: "Never", "At end of text only", "Always"
- Update French, German, and Spanish translations to match
- Fix German label capitalization (`&pausen kürzen` → `&Pausen kürzen`)

## Test plan

- [ ] Build the add-on with `scons` and install in NVDA
- [ ] Open Speech settings and verify the combo box reads "Shorten pauses"
- [ ] Verify the three items display as "Never", "At end of text only", "Always"
- [ ] Switch NVDA language to German/French/Spanish and verify translated labels