### PR TITLE
Fix cp1252 dropping stroke characters like Đ and ł

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -205,9 +205,7 @@ class EloquenceHostClient:
 				listener.close()
 			except Exception:
 				pass
-			raise RuntimeError(
-				f"Eloquence host process failed to start: {exc}"
-			) from exc
+			raise RuntimeError(f"Eloquence host process failed to start: {exc}") from exc
 		self._host = HostProcess(process=proc, connection=conn, listener=listener)
 		self._receiver = threading.Thread(target=self._receiver_loop, daemon=True)
 		self._receiver.start()
@@ -502,7 +500,16 @@ def speak(text):
 	try:
 		# Use appropriate encoding for Asian languages
 		encoding = LANG_ENCODINGS.get(_current_lang, "mbcs")
-		text_bytes = text.encode(encoding, errors="replace")
+		if encoding == "mbcs":
+			# Use Windows best-fit mapping so characters like Đ→D, ł→l
+			# instead of becoming '?' (see issue #90).
+			from ._text_preprocessing import _wchar_to_mbcs
+
+			text_bytes = _wchar_to_mbcs(text)
+			if text_bytes is None:
+				text_bytes = text.encode("mbcs", errors="replace")
+		else:
+			text_bytes = text.encode(encoding, errors="replace")
 		_client.send_command("addText", text=text_bytes, wait=False)
 	except Exception:
 		LOGGER.exception("Failed to send text to synthesizer")

--- a/addon/synthDrivers/_text_preprocessing.py
+++ b/addon/synthDrivers/_text_preprocessing.py
@@ -6,6 +6,7 @@ point -- ``preprocess()`` -- that applies the appropriate fixes for a given
 Eloquence voice.
 """
 
+import ctypes
 import re
 import unicodedata
 
@@ -122,23 +123,60 @@ def _strip_accents(s):
 	return "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
 
 
-def _normalize_text(s):
-	"""Normalize text by removing characters outside the MBCS encoding page.
+def _wchar_to_mbcs(text, code_page=0):
+	"""Encode Unicode to MBCS bytes using Windows best-fit character mapping.
 
-	Tries to preserve accented characters that fall within the active MBCS
-	code page and replaces others with their closest ASCII equivalent or
-	``?`` as a last resort.
+	Calls ``WideCharToMultiByte`` with *dwFlags=0*, which enables Windows
+	best-fit mapping for characters outside the target code page (e.g.
+	Đ→D, ł→l) instead of replacing them with ``?``.
+
+	Args:
+		text: Unicode string to convert.
+		code_page: Windows code page (0 = CP_ACP, the system default).
+
+	Returns:
+		Encoded bytes, or *None* if the conversion fails entirely.
 	"""
+	if not text:
+		return b""
+	_WideCharToMultiByte = ctypes.windll.kernel32.WideCharToMultiByte
+	size = _WideCharToMultiByte(code_page, 0, text, len(text), None, 0, None, None)
+	if size == 0:
+		return None
+	buf = ctypes.create_string_buffer(size)
+	if _WideCharToMultiByte(code_page, 0, text, len(text), buf, size, None, None) == 0:
+		return None
+	return buf.raw
+
+
+def _normalize_text(s):
+	"""Normalize text to fit the active MBCS code page.
+
+	Uses Windows best-fit character mapping via ``WideCharToMultiByte`` so
+	that characters like Đ and ł are mapped to their closest equivalents
+	(D, l) instead of being replaced with ``?``.
+	"""
+	encoded = _wchar_to_mbcs(s)
+	if encoded is not None:
+		try:
+			return encoded.decode("mbcs")
+		except UnicodeDecodeError:
+			pass
+	# Fallback: per-character approach (should rarely trigger)
 	result = []
 	for c in s:
-		try:
-			cc = c.encode("mbcs").decode("mbcs")
-		except UnicodeEncodeError:
-			cc = _strip_accents(c)
+		char_bytes = _wchar_to_mbcs(c)
+		if char_bytes is not None:
 			try:
-				cc.encode("mbcs")
-			except UnicodeEncodeError:
-				cc = "?"
+				result.append(char_bytes.decode("mbcs"))
+				continue
+			except UnicodeDecodeError:
+				pass
+		cc = _strip_accents(c)
+		try:
+			cc.encode("mbcs")
+		except UnicodeEncodeError:
+			cc = "?"
 		result.append(cc)
 	return "".join(result)
 


### PR DESCRIPTION
Closes #90

## Summary
- Use Windows `WideCharToMultiByte` with best-fit mapping (`dwFlags=0`) instead of Python's `str.encode("mbcs")` for text normalization and encoding
- Characters like Đ (U+0110), ł (U+0142) are now mapped to their closest equivalents (D, l) instead of being silently replaced with "?"
- Same approach as the IBMTTS fix (davidacm/NVDA-IBMTTS-Driver#127)

## Changes
- **`_text_preprocessing.py`**: Added `_wchar_to_mbcs()` helper wrapping `WideCharToMultiByte`, updated `_normalize_text()` to use it with fallback to the previous strip-accents logic
- **`_eloquence.py`**: Updated `speak()` to use `_wchar_to_mbcs()` for Western language encoding as a defensive measure

## Test plan
- [x] Đ, đ, Ł, ł are spoken as D, d, L, l (previously silent)
- [x] Normal cp1252 characters (é, ü, ñ, à) are preserved and spoken correctly
- [x] Full string test: "Paweł" spoken as "Pawel", "Łódź" spoken as "Lodz"
- [x] Asian languages unaffected (separate encoding path)