### PR TITLE
Update README for clarity and copy helper button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,32 @@
-# eloquence_threshold
-Eloquence synthesizer NVDA add-on compatible with 64-bit NVDA. Supports Python 3 and new NVDA speech framework.
+# Eloquence for NVDA
+
+Eloquence synthesizer add-on for NVDA with full 64-bit support.
 
 ## 64-bit support
 
-As NVDA migrates to a 64-bit runtime, the Eloquence synthesizer DLL must be
-loaded from a 32-bit process.  This add-on now launches a dedicated helper
-process that hosts the original 32-bit DLL and streams synthesized audio back
-to NVDA using a lightweight RPC channel.  The integration is transparent to the
-user—no additional Python installation or manual steps are required.
+The Eloquence DLL is 32-bit only. This add-on launches a lightweight helper
+process (`eloquence_host32.exe`) that hosts the DLL and streams audio back to
+64-bit NVDA over IPC. The integration is transparent — no additional Python
+installation or manual steps are required.
 
-For development scenarios where the prebuilt helper executable is unavailable
+For development scenarios where the prebuilt helper executable is unavailable,
 the `ELOQUENCE_HOST_COMMAND` environment variable can be set to the command that
 launches a compatible 32-bit Python interpreter with `host_eloquence32.py`.
 
-## Getting Eloquence to Work on Secure, Log-on, and Start-up Screens
+## Eloquence on secure screens (logon, UAC, start-up)
 
-With NVDA 64-bit, you may notice that Eloquence is not available when NVDA enters log-on, start-up, or other secure screens.
+NVDA does **not** copy `*.exe` files to its secure-screen configuration for
+security reasons, so `eloquence_host32.exe` is missing after you click
+**"Use currently saved settings during sign-in"** in NVDA's General settings.
 
-When NVDA copies add-ons for use on secure screens, it does **not** copy any `*.exe` files for security reasons. For Eloquence, the specific file that is **not** copied when selecting **"Use currently saved settings during sign-in and on secure screens"** from the General pane of NVDA's Settings dialog is:
+The easiest way to fix this is the built-in button in the add-on:
 
-```
-eloquence_host32.exe
-```
+1. Open **NVDA Settings > Eloquence**.
+2. Click **"Copy Helper to System Config (for Logon Screen)"**.
+3. Accept the UAC elevation prompt.
 
-By default, this file is located at:
-
-```
-C:\Users\YourUsername\AppData\Roaming\nvda\addons\Eloquence\synthDrivers\
-```
-
-To enable Eloquence on  start-up, secure, and log-on screens in NVDA 64-bit, manually copy the file `eloquence_host32.exe` to:
-
-```
-C:\Program Files\NVDA\systemConfig\addons\Eloquence\synthDrivers\
-```
-
-If you have an admin-level user account, the correct source path may instead be:
-
-```
-C:\Users\admin_your-username\AppData\Roaming\nvda\addons\Eloquence\synthDrivers\
-```
-
-After copying the file, Eloquence should load normally on secure and log-on screens.
+Eloquence should now load on secure and logon screens. You only need to do this
+once per add-on update.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- Replace manual file-copy instructions for secure screens with the built-in "Copy Helper to System Config" button
- Tighten 64-bit architecture section
- Fix title from `eloquence_threshold` to `Eloquence for NVDA`

## Test plan
- [x] Verify README renders correctly on GitHub