### PR TITLE
Fix language override persisting after leaving multilingual content

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import glob
 from pathlib import Path
 
 from SCons.Script import Environment, EnsurePythonVersion
@@ -20,8 +21,6 @@ env.Append(**buildVars.addon_info)
 addonDir = Path("addon")
 
 # --- Compile translations (.po -> .mo) -------------------------------------
-
-import glob
 
 # Find all .po files under addon/locale
 poFiles = glob.glob("addon/locale/*/LC_MESSAGES/*.po")

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -868,6 +868,18 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		for pr in (_eloquence.rate, _eloquence.pitch, _eloquence.vlm):
 			outlist.append((_eloquence.cmdProsody, (pr, 1, 0)))
 
+		# Reset voice to default at the start of each utterance so that
+		# language overrides from the previous sequence don't leak into
+		# untagged speech (issue #97).
+		if getattr(self, "_languageOverrideActive", False):
+			default_voice = getattr(self, "_defaultVoice", None)
+			if default_voice is not None:
+				try:
+					outlist.append((_eloquence.set_voice, (int(default_voice),)))
+					self._update_voice_state(int(default_voice), update_default=False)
+				except (TypeError, ValueError):
+					pass
+
 		# IBMTTS Logic: Combine strings before processing regex
 		speechSequence = self.combine_adjacent_strings(speechSequence)
 

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -789,6 +789,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 				voice_info = _eloquence.langs.get(configured_voice) or _eloquence.langs.get("enu")
 				voice_param = voice_info[0] if voice_info else 65536
 			self._update_voice_state(voice_param, update_default=True)
+			self._cancelledOverrideVoice = None
 			# Initialize _rate first before setting the rate property
 			self._rate = self._percentToParam(50, minRate, maxRate)
 			self.rate = 50
@@ -862,16 +863,29 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		outlist = []
 		pending_indexes = []
 		queued_speech = False
+		cleared_override_voice = None
 
 		# Reset prosody to baseline at the start of each utterance to prevent
 		# state leaks from previous speech sequences (issue #59).
 		for pr in (_eloquence.rate, _eloquence.pitch, _eloquence.vlm):
 			outlist.append((_eloquence.cmdProsody, (pr, 1, 0)))
 
-		# Reset voice to default at the start of each utterance so that
-		# language overrides from the previous sequence don't leak into
-		# untagged speech (issue #97).
-		if getattr(self, "_languageOverrideActive", False):
+		# Language override reset (issue #97).
+		# Two paths: if cancel() preceded this speak(), suppress the first
+		# LangChangeCommand that re-applies the cleared language (it is stale
+		# context from NVDA's SpeechManager).  If no cancel (e.g. sayAll),
+		# reset the voice but honour subsequent LangChangeCommands normally.
+		cancelled_voice = getattr(self, "_cancelledOverrideVoice", None)
+		if cancelled_voice is not None:
+			default_voice = getattr(self, "_defaultVoice", None)
+			if default_voice is not None:
+				try:
+					outlist.append((_eloquence.set_voice, (int(default_voice),)))
+				except (TypeError, ValueError):
+					pass
+			cleared_override_voice = str(cancelled_voice)
+			self._cancelledOverrideVoice = None
+		elif getattr(self, "_languageOverrideActive", False):
 			default_voice = getattr(self, "_defaultVoice", None)
 			if default_voice is not None:
 				try:
@@ -930,6 +944,22 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 					log.debug("No Eloquence voice mapped for language '%s'", item.lang)
 					continue
 				voice_str = str(voice_id)
+				# Suppress a stale leading LangChangeCommand that re-applies
+				# the language we just cleared after cancel() (issue #97).
+				if (
+					cleared_override_voice is not None
+					and not queued_speech
+					and voice_str == cleared_override_voice
+				):
+					log.debug(
+						"Suppressing stale LangChangeCommand('%s') matching cancelled override voice %s",
+						item.lang,
+						cleared_override_voice,
+					)
+					cleared_override_voice = None
+					continue
+				if cleared_override_voice is not None:
+					cleared_override_voice = None
 				if voice_str == self.curvoice:
 					if item.lang is None:
 						self._languageOverrideActive = False
@@ -1205,6 +1235,12 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		return _eloquence.lastindex
 
 	def cancel(self):
+		if getattr(self, "_languageOverrideActive", False):
+			self._cancelledOverrideVoice = self.curvoice
+			default_voice = getattr(self, "_defaultVoice", None)
+			if default_voice is not None:
+				self.curvoice = str(default_voice)
+			self._languageOverrideActive = False
 		_eloquence.stop()
 
 	def _getAvailableVariants(self):

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -789,7 +789,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 				voice_info = _eloquence.langs.get(configured_voice) or _eloquence.langs.get("enu")
 				voice_param = voice_info[0] if voice_info else 65536
 			self._update_voice_state(voice_param, update_default=True)
-			self._cancelledOverrideVoice = None
 			# Initialize _rate first before setting the rate property
 			self._rate = self._percentToParam(50, minRate, maxRate)
 			self.rate = 50
@@ -863,36 +862,20 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		outlist = []
 		pending_indexes = []
 		queued_speech = False
-		cleared_override_voice = None
+		sequence_voice = getattr(self, "_defaultVoice", str(_eloquence.params.get(9, 65536)))
+		last_queued_engine_voice = getattr(self, "_lastEngineVoice", None)
 
 		# Reset prosody to baseline at the start of each utterance to prevent
 		# state leaks from previous speech sequences (issue #59).
 		for pr in (_eloquence.rate, _eloquence.pitch, _eloquence.vlm):
 			outlist.append((_eloquence.cmdProsody, (pr, 1, 0)))
 
-		# Language override reset (issue #97).
-		# Two paths: if cancel() preceded this speak(), suppress the first
-		# LangChangeCommand that re-applies the cleared language (it is stale
-		# context from NVDA's SpeechManager).  If no cancel (e.g. sayAll),
-		# reset the voice but honour subsequent LangChangeCommands normally.
-		cancelled_voice = getattr(self, "_cancelledOverrideVoice", None)
-		if cancelled_voice is not None:
-			default_voice = getattr(self, "_defaultVoice", None)
-			if default_voice is not None:
-				try:
-					outlist.append((_eloquence.set_voice, (int(default_voice),)))
-				except (TypeError, ValueError):
-					pass
-			cleared_override_voice = str(cancelled_voice)
-			self._cancelledOverrideVoice = None
-		elif getattr(self, "_languageOverrideActive", False):
-			default_voice = getattr(self, "_defaultVoice", None)
-			if default_voice is not None:
-				try:
-					outlist.append((_eloquence.set_voice, (int(default_voice),)))
-					self._update_voice_state(int(default_voice), update_default=False)
-				except (TypeError, ValueError):
-					pass
+		if last_queued_engine_voice != sequence_voice:
+			try:
+				outlist.append((_eloquence.set_voice, (int(sequence_voice),)))
+				last_queued_engine_voice = sequence_voice
+			except (TypeError, ValueError):
+				log.debug("Skipping default voice reset for invalid voice id %r", sequence_voice)
 
 		# IBMTTS Logic: Combine strings before processing regex
 		speechSequence = self.combine_adjacent_strings(speechSequence)
@@ -900,7 +883,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		for item in speechSequence:
 			if isinstance(item, str):
 				s = str(item)
-				s = self.xspeakText(s)
+				s = self.xspeakText(s, voice_id=sequence_voice)
 				outlist.append((_eloquence.speak, (s,)))
 				last = s
 				queued_speech = True
@@ -944,25 +927,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 					log.debug("No Eloquence voice mapped for language '%s'", item.lang)
 					continue
 				voice_str = str(voice_id)
-				# Suppress a stale leading LangChangeCommand that re-applies
-				# the language we just cleared after cancel() (issue #97).
-				if (
-					cleared_override_voice is not None
-					and not queued_speech
-					and voice_str == cleared_override_voice
-				):
-					log.debug(
-						"Suppressing stale LangChangeCommand('%s') matching cancelled override voice %s",
-						item.lang,
-						cleared_override_voice,
-					)
-					cleared_override_voice = None
-					continue
-				if cleared_override_voice is not None:
-					cleared_override_voice = None
-				if voice_str == self.curvoice:
-					if item.lang is None:
-						self._languageOverrideActive = False
+				if voice_str == sequence_voice:
 					continue
 				try:
 					queued_voice = int(voice_id)
@@ -974,7 +939,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 					)
 					continue
 				outlist.append((_eloquence.set_voice, (queued_voice,)))
-				self._update_voice_state(queued_voice, update_default=item.lang is None)
+				sequence_voice = voice_str
+				last_queued_engine_voice = voice_str
 			elif type(item) in self.PROSODY_ATTRS:
 				pr = self.PROSODY_ATTRS[type(item)]
 				# Use the raw _offset/_multiplier values directly, NOT the
@@ -1003,6 +969,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 					func(*args)
 				except Exception:
 					log.exception("Synthesis command failed")
+			self._lastEngineVoice = last_queued_engine_voice
 			for index in pending_indexes:
 				synthIndexReached.notify(synth=self, index=index)
 			synthDoneSpeaking.notify(synth=self)
@@ -1017,12 +984,19 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
 		outlist.append((_eloquence.index, (0xFFFF,)))
 		outlist.append((_eloquence.synth, ()))
+		self._lastEngineVoice = last_queued_engine_voice
 		seq = _eloquence._client._sequence
 		_eloquence.synth_queue.put((outlist, seq))
 		_eloquence.process()
 
-	def xspeakText(self, text, should_pause=False):
-		text = _text_preprocessing.preprocess(text, _eloquence.params[9])
+	def xspeakText(self, text, voice_id=None, should_pause=False):
+		if voice_id is None:
+			voice_id = getattr(self, "_defaultVoice", _eloquence.params.get(9))
+		try:
+			voice_id = int(voice_id)
+		except (TypeError, ValueError):
+			log.debug("Preprocessing text with invalid voice id %r; using raw value", voice_id)
+		text = _text_preprocessing.preprocess(text, voice_id)
 		if not self._backquoteVoiceTags:
 			text = text.replace("`", " ")
 		text = "`vv%d %s" % (
@@ -1170,7 +1144,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		return o
 
 	def _get_voice(self):
-		return str(_eloquence.params[9])
+		return getattr(self, "_defaultVoice", str(_eloquence.params[9]))
 
 	def _set_voice(self, vl):
 		_eloquence.set_voice(vl)
@@ -1184,11 +1158,9 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			log.debug("Unable to coerce Eloquence voice id '%s' to int", voice_id)
 		if update_default or not getattr(self, "_defaultVoice", None):
 			self._defaultVoice = voice_str
-		self.curvoice = voice_str
-		current_default = getattr(self, "_defaultVoice", None)
-		self._languageOverrideActive = (
-			(not update_default) and current_default is not None and voice_str != current_default
-		)
+		self.curvoice = self._defaultVoice
+		self._lastEngineVoice = voice_str
+		self._languageOverrideActive = False
 
 	def _resolve_voice_for_language(self, language):
 		if not language:
@@ -1235,12 +1207,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		return _eloquence.lastindex
 
 	def cancel(self):
-		if getattr(self, "_languageOverrideActive", False):
-			self._cancelledOverrideVoice = self.curvoice
-			default_voice = getattr(self, "_defaultVoice", None)
-			if default_voice is not None:
-				self.curvoice = str(default_voice)
-			self._languageOverrideActive = False
+		self._lastEngineVoice = None
+		self._languageOverrideActive = False
 		_eloquence.stop()
 
 	def _getAvailableVariants(self):

--- a/tests/test_language_scope.py
+++ b/tests/test_language_scope.py
@@ -1,0 +1,316 @@
+import builtins
+import importlib
+import sys
+import types
+import unittest
+
+
+class _Command:
+	def __init__(self, **kwargs):
+		self.__dict__.update(kwargs)
+
+
+class IndexCommand(_Command):
+	def __init__(self, index):
+		super().__init__(index=index)
+
+
+class LangChangeCommand(_Command):
+	def __init__(self, lang):
+		super().__init__(lang=lang)
+
+
+class BreakCommand(_Command):
+	def __init__(self, time):
+		super().__init__(time=time)
+
+
+class CharacterModeCommand(_Command):
+	pass
+
+
+class PitchCommand(_Command):
+	pass
+
+
+class RateCommand(_Command):
+	pass
+
+
+class VolumeCommand(_Command):
+	pass
+
+
+class PhonemeCommand(_Command):
+	pass
+
+
+class _Notification:
+	def __init__(self):
+		self.calls = []
+
+	def notify(self, **kwargs):
+		self.calls.append(kwargs)
+
+
+class _SynthBase:
+	@staticmethod
+	def VoiceSetting():
+		return object()
+
+	@staticmethod
+	def VariantSetting():
+		return object()
+
+	@staticmethod
+	def RateSetting():
+		return object()
+
+	@staticmethod
+	def PitchSetting():
+		return object()
+
+	@staticmethod
+	def InflectionSetting():
+		return object()
+
+	@staticmethod
+	def VolumeSetting():
+		return object()
+
+	def _percentToParam(self, value, min_value, max_value):
+		return int(min_value + (max_value - min_value) * value / 100)
+
+	def _paramToPercent(self, value, min_value, max_value):
+		return int((value - min_value) * 100 / (max_value - min_value))
+
+
+class _SpeechQueue:
+	def __init__(self):
+		self.items = []
+
+	def put(self, item):
+		self.items.append(item)
+
+
+class _EloquenceStub(types.ModuleType):
+	def __init__(self):
+		super().__init__("addon.synthDrivers._eloquence")
+		self.params = {9: 262144}
+		self.voice_params = {7: 80}
+		self.lastindex = None
+		self.hsz = 1
+		self.pitch = 2
+		self.fluctuation = 3
+		self.rgh = 4
+		self.bth = 5
+		self.rate = 6
+		self.vlm = 7
+		self.eciPath = "C:\\eci.dll"
+		self.langs = {
+			"enu": (65536, "American English"),
+			"eng": (65537, "British English"),
+			"deu": (262144, "German"),
+			"esp": (131072, "Castilian Spanish"),
+			"esm": (131073, "Latin American Spanish"),
+			"fra": (196608, "French"),
+			"frc": (196609, "French Canadian"),
+			"ptb": (458752, "Brazilian Portuguese"),
+			"fin": (589824, "Finnish"),
+			"ita": (327680, "Italian"),
+			"chs": (393216, "Mandarin Chinese"),
+			"jpn": (524288, "Japanese"),
+			"kor": (655360, "Korean"),
+		}
+		self.synth_queue = _SpeechQueue()
+		self._client = types.SimpleNamespace(_sequence=1)
+		self.stopped = False
+		self.processed = False
+		self.immediate_calls = []
+
+	def cmdProsody(self, *args):
+		self.immediate_calls.append(("cmdProsody", args))
+
+	def set_voice(self, voice_id):
+		self.params[9] = int(voice_id)
+		self.immediate_calls.append(("set_voice", (int(voice_id),)))
+
+	def speak(self, text):
+		self.immediate_calls.append(("speak", (text,)))
+
+	def index(self, index):
+		self.immediate_calls.append(("index", (index,)))
+
+	def synth(self):
+		self.immediate_calls.append(("synth", ()))
+
+	def process(self):
+		self.processed = True
+
+	def stop(self):
+		self.stopped = True
+
+	def getVParam(self, param):
+		return self.voice_params.get(param, 0)
+
+
+def _install_nvda_stubs():
+	builtins._ = lambda text: text
+	speech = types.ModuleType("speech")
+	speech.IndexCommand = IndexCommand
+	speech.CharacterModeCommand = CharacterModeCommand
+	speech.LangChangeCommand = LangChangeCommand
+	speech.BreakCommand = BreakCommand
+	speech.PitchCommand = PitchCommand
+	speech.RateCommand = RateCommand
+	speech.VolumeCommand = VolumeCommand
+	speech.PhonemeCommand = PhonemeCommand
+	sys.modules["speech"] = speech
+
+	driver_handler = types.ModuleType("driverHandler")
+	driver_handler.NumericDriverSetting = lambda *args, **kwargs: object()
+	driver_handler.BooleanDriverSetting = lambda *args, **kwargs: object()
+	driver_handler.DriverSetting = lambda *args, **kwargs: object()
+	sys.modules["driverHandler"] = driver_handler
+
+	synth_driver_handler = types.ModuleType("synthDriverHandler")
+	synth_driver_handler.SynthDriver = _SynthBase
+	synth_driver_handler.synthIndexReached = _Notification()
+	synth_driver_handler.synthDoneSpeaking = _Notification()
+	synth_driver_handler.VoiceInfo = lambda *args, **kwargs: types.SimpleNamespace(
+		id=args[0] if args else None,
+		name=args[1] if len(args) > 1 else None,
+		language=args[2] if len(args) > 2 else None,
+	)
+	sys.modules["synthDriverHandler"] = synth_driver_handler
+
+	gui = types.ModuleType("gui")
+	gui.settingsDialogs = types.SimpleNamespace(SettingsPanel=object)
+	gui.guiHelper = types.SimpleNamespace()
+	gui.messageBox = lambda *args, **kwargs: None
+	sys.modules["gui"] = gui
+	sys.modules["wx"] = types.ModuleType("wx")
+	sys.modules["winsound"] = types.ModuleType("winsound")
+	sys.modules["config"] = types.SimpleNamespace(conf={})
+	sys.modules["core"] = types.SimpleNamespace(
+		postNvdaStartup=types.SimpleNamespace(register=lambda f: None)
+	)
+	sys.modules["globalVars"] = types.SimpleNamespace(appArgs=types.SimpleNamespace(secure=False))
+	sys.modules["addonHandler"] = types.SimpleNamespace(initTranslation=lambda: None)
+
+
+def _load_driver():
+	_install_nvda_stubs()
+	eloquence_stub = _EloquenceStub()
+	sys.modules["addon.synthDrivers._eloquence"] = eloquence_stub
+	sys.modules.pop("addon.synthDrivers.eloquence", None)
+	module = importlib.import_module("addon.synthDrivers.eloquence")
+	preprocess_calls = []
+
+	def preprocess(text, voice_id):
+		preprocess_calls.append((text, voice_id))
+		return f"{voice_id}:{text}"
+
+	module._text_preprocessing.preprocess = preprocess
+	return module, eloquence_stub, preprocess_calls
+
+
+def _new_driver(module):
+	driver = module.SynthDriver.__new__(module.SynthDriver)
+	driver._defaultVoice = "262144"
+	driver.curvoice = "262144"
+	driver._lastEngineVoice = "262144"
+	driver._languageOverrideActive = False
+	driver._pause_mode = 1
+	driver._backquoteVoiceTags = False
+	driver._ABRDICT = False
+	driver._phrasePrediction = False
+	return driver
+
+
+def _queued_calls(eloquence_stub):
+	return eloquence_stub.synth_queue.items[-1][0]
+
+
+def _queued_voice_ids(calls, eloquence_stub):
+	return [
+		args[0]
+		for func, args in calls
+		if getattr(func, "__self__", None) is eloquence_stub and getattr(func, "__name__", "") == "set_voice"
+	]
+
+
+def _queued_text(calls, eloquence_stub):
+	return [
+		args[0]
+		for func, args in calls
+		if getattr(func, "__self__", None) is eloquence_stub and getattr(func, "__name__", "") == "speak"
+	]
+
+
+class LanguageScopeTests(unittest.TestCase):
+	def test_english_document_language_does_not_replace_default_voice(self):
+		module, eloquence_stub, preprocess_calls = _load_driver()
+		driver = _new_driver(module)
+
+		driver.speak([LangChangeCommand("en-US"), "Collapse tree"])
+
+		calls = _queued_calls(eloquence_stub)
+		self.assertEqual(_queued_voice_ids(calls, eloquence_stub), [65536])
+		self.assertEqual(preprocess_calls, [("Collapse tree", 65536)])
+		self.assertEqual(driver._get_voice(), "262144")
+		self.assertEqual(driver.curvoice, "262144")
+
+	def test_cancel_does_not_suppress_next_english_language_command(self):
+		module, eloquence_stub, preprocess_calls = _load_driver()
+		driver = _new_driver(module)
+
+		driver.speak([LangChangeCommand("en-US"), "Repository"])
+		driver.cancel()
+		driver.speak([LangChangeCommand("en-US"), "Collapse tree"])
+
+		second_calls = eloquence_stub.synth_queue.items[-1][0]
+		self.assertEqual(_queued_voice_ids(second_calls, eloquence_stub), [262144, 65536])
+		self.assertEqual(preprocess_calls[-1], ("Collapse tree", 65536))
+		self.assertEqual(driver._get_voice(), "262144")
+
+	def test_german_ui_without_language_command_uses_default_after_english_content(self):
+		module, eloquence_stub, preprocess_calls = _load_driver()
+		driver = _new_driver(module)
+
+		driver.speak([LangChangeCommand("en-US"), "Repository"])
+		driver.speak(["Desktop"])
+
+		second_calls = eloquence_stub.synth_queue.items[-1][0]
+		self.assertEqual(_queued_voice_ids(second_calls, eloquence_stub), [262144])
+		self.assertEqual(preprocess_calls[-1], ("Desktop", 262144))
+		self.assertEqual(driver._get_voice(), "262144")
+
+	def test_language_reset_uses_default_for_say_all_structural_text(self):
+		module, eloquence_stub, preprocess_calls = _load_driver()
+		driver = _new_driver(module)
+
+		driver.speak([LangChangeCommand("en-US"), "README", LangChangeCommand(None), "list end"])
+
+		calls = _queued_calls(eloquence_stub)
+		self.assertEqual(_queued_voice_ids(calls, eloquence_stub), [65536, 262144])
+		self.assertEqual(
+			preprocess_calls,
+			[("README", 65536), ("list end", 262144)],
+		)
+		self.assertEqual(driver._get_voice(), "262144")
+
+	def test_index_only_sequence_still_notifies_progress_and_done(self):
+		module, eloquence_stub, _preprocess_calls = _load_driver()
+		driver = _new_driver(module)
+
+		driver.speak([IndexCommand(42)])
+
+		self.assertEqual(module.synthIndexReached.calls, [{"synth": driver, "index": 42}])
+		self.assertEqual(module.synthDoneSpeaking.calls, [{"synth": driver}])
+		self.assertEqual(eloquence_stub.synth_queue.items, [])
+		self.assertFalse(eloquence_stub.processed)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Fixes #97

## Summary
- When automatic language switching activates (e.g. visiting an English website with NVDA set to German), the switched voice leaked into subsequent `speak()` calls that contained no `LangChangeCommand` — such as pressing Win+M to go to the desktop.
- At the start of each `speak()` call, if a language override is active, reset the voice back to `_defaultVoice`. This mirrors the existing prosody reset pattern (issue #59). If the new speech sequence contains its own `LangChangeCommand`, it will override this reset as expected.

## Test plan
- Set NVDA language to German (or any non-English language) with automatic language switching enabled
- Visit an English website so Eloquence switches to the English voice
- Press Win+M or switch to another application
- Verify Eloquence speaks in German again (the configured default)
- Return to the English website and verify it still switches to English correctly