### PR TITLE
Add v17 troubleshooting docs and #103 polish items

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,40 @@ The easiest way to fix this is the built-in button in the add-on:
 Eloquence should now load on secure and logon screens. You only need to do this
 once per add-on update.
 
+## Troubleshooting
+
+### "Could not load the synthesizer" after upgrading
+
+If you upgraded from v16 (or earlier) to v17+ and NVDA reports **"Could not load
+the synthesizer"** when you select Eloquence, the NVDA log most likely shows:
+
+```
+AttributeError: module 'synthDrivers._ipc' has no attribute 'create_listener'
+```
+
+This is caused by one or more of:
+
+- Stale Python bytecode (`__pycache__`) left over from the previous version.
+- A half-finished NVDA upgrade leaving an `Eloquence.delete` folder alongside
+  the new install.
+- The IBMTTS add-on also being installed — running both at the same time is
+  not supported.
+
+To recover, do a clean reinstall:
+
+1. In NVDA, open **Tools → Manage Add-ons**, disable Eloquence, and restart
+   NVDA so the disable takes effect.
+2. In File Explorer, open `%APPDATA%\nvda\addons\` and delete the entire
+   `Eloquence` folder. While you're there, delete any sibling folders whose
+   names end in `.delete`.
+3. If the IBMTTS add-on is installed, disable or remove it as well.
+4. Restart NVDA, then install the latest Eloquence release fresh.
+5. As a last resort, back up `%APPDATA%\nvda` and remove it to start with a
+   clean NVDA config.
+
+See [issue #101](https://github.com/fastfinge/eloquence_64/issues/101) for the
+background.
+
 ## Building
 
 ### Prerequisites

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -113,7 +113,7 @@ for code, lang in VOICE_BCP47.items():
 
 variants = {
 	1: "Reed",
-	2: "Shelley",
+	2: "Shelly",
 	3: "Bobby",
 	4: "Rocko",
 	5: "Glen",

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,6 +30,6 @@ addon_info = {
 	"addon_description": "Eloquence synthesizer for NVDA with 64-bit support",
 	"addon_version": _get_version(),
 	"addon_author": "NVDA User",
-	"addon_url": "https://github.com/pumper42nickel/eloquence_threshold",
+	"addon_url": "https://github.com/fastfinge/eloquence_64",
 	"addon_lastTestedNVDAVersion": "2034.1",
 }

--- a/tts.txt
+++ b/tts.txt
@@ -3244,7 +3244,7 @@ Choosing a Speaker
 ECI annotations for each language and speaker, as indicated. 
 ECI Annotation Description
 `l1.0 `v1 Set voice to the “Reed,” the American English adult male voice.
-`l1.0 `v2 Set voice to “Shelley,” the American English adult female voice.
+`l1.0 `v2 Set voice to “Shelly,” the American English adult female voice.
 `l1.0 `v3 Set voice to “Sandy,” the American English child voice.
 `l1.0 `v7 Set voice to “Grandma,” the American English elderly female voice.
 `l1.0 `v8 Set voice to “Grandpa,” the American English elderly male voice.


### PR DESCRIPTION
## Summary

- **README:** new Troubleshooting section for the v17 "Could not load the synthesizer" failure. Documents the stale `__pycache__` / `.delete` folder / IBMTTS-conflict chain surfaced in #101, with the clean-reinstall steps that have been pasted into the issue thread repeatedly.
- **buildVars.py:** `addon_url` → `https://github.com/fastfinge/eloquence_64` (#103 item 1 — the manifest was still pointing at `pumper42nickel/eloquence_threshold`).
- **Shelley → Shelly variant rename** (#103 item 3). Display-label only; variants persist by numeric id, so existing user configs are unaffected.

The new pause-mode option (#103 item 2) is deferred to a separate PR — it's a feature (~30–50 lines + translations + behavior testing) and doesn't fit this docs/polish shape.

A wrapper around `_ipc.create_listener()` to give a friendlier error was considered and rejected: the user-reported `AttributeError` fires inside stale v16 bytecode, not in v17 source, so a v17-side wrapper can't actually catch it. The README is the right place to address this.

## Test plan

- [ ] `scons` builds successfully and the generated `addon/manifest.ini` shows `url = https://github.com/fastfinge/eloquence_64`
- [ ] Install the built `.nvda-addon` and confirm the Variant dropdown in NVDA Settings → Eloquence shows "Shelly" at position 2
- [ ] Load an NVDA config that previously selected "Shelley" (variant id 2) and confirm it still resolves cleanly
- [ ] Smoke test on a fresh install (no IBMTTS, no stale folders): Eloquence loads and produces speech

Refs #101 (does not close — the underlying user-machine state still requires the manual steps the README now documents). Partially closes #103 (items 1 and 3).