### PR TITLE
Fix Eloquence halt on em dash plus smart quote

### DIFF
--- a/addon/synthDrivers/_text_preprocessing.py
+++ b/addon/synthDrivers/_text_preprocessing.py
@@ -33,6 +33,8 @@ english_fixes = {
 	): r"\1 \2",
 	# caesure / cæsure crash
 	re.compile(r"c(ae|\xe6)sur(e)?", re.I): r"seizur",
+	# Em dash immediately followed by right double quote stalls Eloquence 17.
+	re.compile(r"\u2014\u201d"): '\u2014 "',
 	# h' + r/v + e crash
 	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",
 	# Consonant cluster + hhes + word continuation (variant 1)

--- a/tests/test_text_preprocessing.py
+++ b/tests/test_text_preprocessing.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from addon.synthDrivers._text_preprocessing import preprocess
 
@@ -14,6 +15,10 @@ class TextPreprocessingTests(unittest.TestCase):
 		for voice_id in (524288, 655360):
 			with self.subTest(voice_id=voice_id):
 				self.assertEqual(preprocess("選設檢", voice_id), "選設檢")
+
+	def test_english_preprocessing_rewrites_em_dash_before_right_double_quote(self):
+		with patch("addon.synthDrivers._text_preprocessing._normalize_text", lambda text: text):
+			self.assertEqual(preprocess('Wait—” she said.', 65536), 'Wait— " she said.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rewrites the Eloquence 17 stall pattern U+2014 U+201D into U+2014 + ASCII quote before synthesis
- adds a regression test for issue #111

## Test plan
- PYTHONPATH=/tmp/eloquence_64 python -m pytest tests/test_text_preprocessing.py -q
- python -m compileall -q addon/synthDrivers/_text_preprocessing.py tests/test_text_preprocessing.py
- uv tool run ruff@0.15.14 check addon/synthDrivers/_text_preprocessing.py tests/test_text_preprocessing.py

Closes #111