### PR TITLE
Install updates through NVDA add-on installer

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+
+import addonHandler
+from logHandler import log
+
+
+def _copy_user_dictionaries(source_dir, target_dir):
+	if not os.path.isdir(source_dir):
+		return 0
+
+	copied = 0
+	os.makedirs(target_dir, exist_ok=True)
+	for filename in os.listdir(source_dir):
+		if not filename.lower().endswith(".dic"):
+			continue
+
+		source_path = os.path.join(source_dir, filename)
+		if not os.path.isfile(source_path):
+			continue
+
+		shutil.copy2(source_path, os.path.join(target_dir, filename))
+		copied += 1
+	return copied
+
+
+def onInstall():
+	addon = addonHandler.getCodeAddon()
+	if os.path.normcase(os.path.normpath(addon.path)) == os.path.normcase(
+		os.path.normpath(addon.installPath)
+	):
+		return
+
+	source_dir = os.path.join(addon.installPath, "synthDrivers", "eloquence")
+	target_dir = os.path.join(addon.path, "synthDrivers", "eloquence")
+	copied = _copy_user_dictionaries(source_dir, target_dir)
+	if copied:
+		log.info("Preserved %s Eloquence dictionary file(s) for pending add-on install", copied)

--- a/addon/synthDrivers/_eloquence_updater.py
+++ b/addon/synthDrivers/_eloquence_updater.py
@@ -1,93 +1,14 @@
 import os
 import json
 import urllib.request
-import zipfile
 import shutil
 import logging
-import wx
 import re
 import addonHandler
 
 addonHandler.initTranslation()
 
 log = logging.getLogger(__name__)
-
-
-class UpdateChangesDialog(wx.Dialog):
-	def __init__(self, parent, changes, latest_version):
-		# Translators: Title of the Review Update Changes dialog used during add-on update.
-		super().__init__(parent, title=_("Review Update Changes"), size=(500, 400))
-
-		main_sizer = wx.BoxSizer(wx.VERTICAL)
-
-		# Summary text
-		# Translators: Text in the Review Update Changes dialog used during add-on update.
-		summary = _("Update to version {latest_version} includes the following changes:").format(
-			latest_version=latest_version
-		)
-		main_sizer.Add(wx.StaticText(self, label=summary), 0, wx.ALL, 10)
-
-		# List of changes
-		self.list_ctrl = wx.ListCtrl(self, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
-		# Translators: Column header in the Review Update Changes dialog used during add-on update.
-		self.list_ctrl.InsertColumn(0, _("Action"), width=100)
-		# Translators: Column header in the Review Update Changes dialog used during add-on update.
-		self.list_ctrl.InsertColumn(1, _("File"), width=350)
-
-		idx = 0
-		for f in changes["added"]:
-			self.list_ctrl.InsertItem(idx, _("Add"))
-			self.list_ctrl.SetItem(idx, 1, f)
-			idx += 1
-		for f in changes["modified"]:
-			# Translators: Action name used in the list of the Review Update Changes dialog used during add-on update.
-			self.list_ctrl.InsertItem(idx, _("Update"))
-			self.list_ctrl.SetItem(idx, 1, f)
-			idx += 1
-		for f in changes["deleted"]:
-			# Translators: Action name used in the list of the Review Update Changes dialog used during add-on update.
-			self.list_ctrl.InsertItem(idx, _("Delete"))
-			self.list_ctrl.SetItem(idx, 1, f)
-			idx += 1
-
-		main_sizer.Add(self.list_ctrl, 1, wx.EXPAND | wx.ALL, 10)
-
-		# Info about preserved files
-		if changes["preserved"]:
-			# Translators: Text in the Review Update Changes dialog used during add-on update.
-			p_text = _(
-				"Note: {n} local configuration/dictionary files will be preserved.",
-			).format(n=len(changes["preserved"]))
-			main_sizer.Add(wx.StaticText(self, label=p_text), 0, wx.ALL, 10)
-
-		# Buttons
-		btn_sizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
-		main_sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
-
-		self.SetSizer(main_sizer)
-		self.Layout()
-
-
-def show_update_dialog(parent, changes, latest_version):
-	"""
-	Shows a dialog with the changes and returns (apply_update, decisions).
-	"""
-	dlg = UpdateChangesDialog(parent, changes, latest_version)
-	result = dlg.ShowModal()
-	dlg.Destroy()
-
-	if result != wx.ID_OK:
-		return False, {}
-
-	decisions = {}
-	for f in changes["added"]:
-		decisions[f] = "add"
-	for f in changes["modified"]:
-		decisions[f] = "update"
-	for f in changes["deleted"]:
-		decisions[f] = "delete"
-
-	return True, decisions
 
 
 class EloquenceUpdateManager:
@@ -97,7 +18,6 @@ class EloquenceUpdateManager:
 	def __init__(self, addon_dir):
 		self.addon_dir = os.path.abspath(addon_dir)
 		self.temp_dir = os.path.join(self.addon_dir, "temp_update")
-		self.extract_dir = os.path.join(self.temp_dir, "extracted")
 		self.CURRENT_VERSION = self._get_current_version()
 
 	def _get_current_version(self):
@@ -129,16 +49,15 @@ class EloquenceUpdateManager:
 			latest_version = data.get("tag_name", "0.0.0").lstrip("v")
 			download_url = None
 
-			# Look for .nvda-addon or .zip in assets
+			# Standard NVDA installation requires a packaged add-on bundle.
 			assets = data.get("assets", [])
 			for asset in assets:
 				if asset["name"].endswith(".nvda-addon"):
 					download_url = asset["browser_download_url"]
 					break
 
-			# If no assets, use the source zip
 			if not download_url:
-				download_url = data.get("zipball_url")
+				raise RuntimeError(_("Latest release does not include an NVDA add-on package."))
 
 			changelog = data.get("body", "No changelog provided.")
 
@@ -161,11 +80,11 @@ class EloquenceUpdateManager:
 			return latest != current
 
 	def download_update(self, download_url, progress_callback):
-		"""Downloads the update and returns the path to the zip file"""
+		"""Downloads the update and returns the path to the add-on package."""
 		if not os.path.exists(self.temp_dir):
 			os.makedirs(self.temp_dir)
 
-		zip_path = os.path.join(self.temp_dir, "update.zip")
+		addon_path = os.path.join(self.temp_dir, "update.nvda-addon")
 
 		try:
 			headers = {"User-Agent": "NVDA-Eloquence-Updater"}
@@ -175,7 +94,7 @@ class EloquenceUpdateManager:
 				downloaded = 0
 				block_size = 8192
 
-				with open(zip_path, "wb") as f:
+				with open(addon_path, "wb") as f:
 					while True:
 						buffer = response.read(block_size)
 						if not buffer:
@@ -189,155 +108,27 @@ class EloquenceUpdateManager:
 								percent, _("Downloading update... {percent}%").format(percent=percent)
 							):
 								raise Exception("Download cancelled by user")
-			return zip_path
+			return addon_path
 		except Exception as e:
 			log.error(f"Error downloading update: {e}")
 			raise
 
-	def extract_update(self, zip_path, progress_callback):
-		"""Extracts the zip file to a temporary directory"""
-		if os.path.exists(self.extract_dir):
-			shutil.rmtree(self.extract_dir)
-		os.makedirs(self.extract_dir)
-
+	def install_update(self, addon_path, parent=None):
+		"""Installs the downloaded package through NVDA's add-on install machinery."""
 		try:
-			with zipfile.ZipFile(zip_path, "r") as zip_ref:
-				files = zip_ref.namelist()
-				total_files = len(files)
-				for i, file in enumerate(files):
-					zip_ref.extract(file, self.extract_dir)
-					percent = int((i + 1) * 100 / total_files)
-					# Translators: Text in the progress dialog used during add-on update.
-					if not progress_callback(percent, _("Extracting... {percent}%").format(percent=percent)):
-						raise Exception("Extraction cancelled by user")
+			from addonStore.install import installAddon
+		except ImportError:
+			from gui import addonGui
 
-			# If it's a GitHub zipball, it extracts into a subfolder
-			contents = os.listdir(self.extract_dir)
-			if len(contents) == 1 and os.path.isdir(os.path.join(self.extract_dir, contents[0])):
-				# Move everything up one level
-				subfolder = os.path.join(self.extract_dir, contents[0])
-				for item in os.listdir(subfolder):
-					dest = os.path.join(self.extract_dir, item)
-					if os.path.exists(dest):
-						if os.path.isdir(dest):
-							shutil.rmtree(dest)
-						else:
-							os.remove(dest)
-					shutil.move(os.path.join(subfolder, item), self.extract_dir)
-				os.rmdir(subfolder)
+			return addonGui.installAddon(parent, addon_path)
 
-		except Exception as e:
-			log.error(f"Error extracting update: {e}")
-			raise
+		installAddon(addon_path)
+		return True
 
-	def analyze_changes(self, progress_callback):
-		"""
-		Analyzes differences between current install and update.
-		Returns a dictionary of changes.
-		"""
-		changes = {
-			"added": [],
-			"modified": [],
-			"deleted": [],
-			"preserved": [],  # Files we want to keep as is
-		}
+	def prompt_for_restart(self):
+		from gui.addonGui import promptUserForRestart
 
-		# Files to always preserve (don't overwrite if exist)
-		preserve_list = ["ECI.INI", "synthDrivers\\eloquence\\"]  # Custom dictionaries
-
-		# Walk through the update files
-		for root, dirs, files in os.walk(self.extract_dir):
-			rel_path = os.path.relpath(root, self.extract_dir)
-			if rel_path == ".":
-				rel_path = ""
-
-			for file in files:
-				file_rel_path = os.path.join(rel_path, file)
-				current_path = os.path.join(self.addon_dir, "../", file_rel_path)
-
-				# Check if it should be preserved
-				is_preserved = False
-				for p in preserve_list:
-					if file_rel_path.startswith(p):
-						is_preserved = True
-						break
-
-				if is_preserved and os.path.exists(current_path):
-					changes["preserved"].append(file_rel_path)
-					continue
-
-				if not os.path.exists(current_path):
-					changes["added"].append(file_rel_path)
-				else:
-					changes["modified"].append(file_rel_path)
-
-		# Check for deleted files
-		exclude_from_deletion = [".git", "temp_update", ".venv", "__pycache__", "eloquence"]
-		for root, dirs, files in os.walk(self.addon_dir):
-			rel_path = os.path.relpath(root, self.addon_dir)
-			if rel_path == ".":
-				rel_path = ""
-
-			if any(rel_path.startswith(e) for e in exclude_from_deletion):
-				continue
-
-			for file in files:
-				file_rel_path = os.path.join(rel_path, file)
-				if any(file_rel_path.startswith(e) for e in exclude_from_deletion):
-					continue
-
-				update_path = os.path.join(self.extract_dir, file_rel_path)
-				if not os.path.exists(update_path):
-					# Check if it's in preserve list
-					is_preserved = False
-					for p in preserve_list:
-						if file_rel_path.startswith(p):
-							is_preserved = True
-							break
-					if not is_preserved:
-						changes["deleted"].append(file_rel_path)
-
-		# Translators: Text in the progress dialog used during add-on update.
-		progress_callback(100, _("Analysis complete"))
-		return changes
-
-	def smart_merge(self, changes, decisions, merge_progress):
-		"""Applies the changes based on user decisions"""
-		total_steps = len(decisions)
-		if total_steps == 0:
-			# Translators: Text in the progress dialog used during add-on update.
-			merge_progress(100, _("No changes to apply"))
-			return
-
-		for i, (file_rel_path, action) in enumerate(decisions.items()):
-			src = os.path.join(self.extract_dir, file_rel_path)
-			dst = os.path.join(self.addon_dir, "../", file_rel_path)
-
-			percent = int((i + 1) * 100 / total_steps)
-			# Translators: Text in the progress dialog used during add-on update.
-			merge_progress(percent, _("Applying: {path}").format(path=file_rel_path))
-
-			try:
-				if action in ("update", "add"):
-					if os.path.isdir(src):
-						if not os.path.exists(dst):
-							os.makedirs(dst)
-					else:
-						dst_dir = os.path.dirname(dst)
-						if not os.path.exists(dst_dir):
-							os.makedirs(dst_dir)
-						shutil.copy2(src, dst)
-				elif action == "delete":
-					if os.path.exists(dst):
-						if os.path.isdir(dst):
-							shutil.rmtree(dst)
-						else:
-							os.remove(dst)
-			except Exception as e:
-				log.error(f"Error applying change to {file_rel_path}: {e}")
-
-		# Translators: Text in the progress dialog used during add-on update.
-		merge_progress(100, _("Update complete"))
+		promptUserForRestart()
 
 	def cleanup(self):
 		"""Removes temporary files"""

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -278,7 +278,7 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 		# Import update manager
 		sys.path.insert(0, addon_dir)
 		try:
-			from _eloquence_updater import EloquenceUpdateManager, show_update_dialog
+			from _eloquence_updater import EloquenceUpdateManager
 		except ImportError as e:
 			wx.MessageBox(
 				# Translators: Text of a message dialog when updating the add-on
@@ -371,24 +371,22 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 				cont, skip = progress.Update(percent, message)
 				return cont
 
-			zip_path = manager.download_update(download_url, download_progress)
-
-			# Extract update
-			# Translators: Text of a progress dialog when updating the add-on
-			progress.Update(0, _("Extracting update..."))
-			manager.extract_update(zip_path, download_progress)
-
-			# Analyze changes
-			# Translators: Text of a progress dialog when updating the add-on
-			progress.Update(0, _("Analyzing changes..."))
-			changes = manager.analyze_changes(download_progress)
-
+			addon_path = manager.download_update(download_url, download_progress)
+			progress.Update(100, _("Download complete"))
 			progress.Destroy()
 
-			# Show update dialog with detailed changes
-			apply_update, decisions = show_update_dialog(self, changes, latest_version)
-
-			if not apply_update:
+			progress = wx.ProgressDialog(
+				# Translators: Text of a progress dialog when updating the add-on
+				_("Installing Update"),
+				# Translators: Text of a progress dialog when updating the add-on
+				_("Please wait..."),
+				maximum=100,
+				parent=self,
+				style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
+			)
+			progress.Pulse(_("Installing add-on package..."))
+			if not manager.install_update(addon_path, self):
+				progress.Destroy()
 				manager.cleanup()
 				wx.MessageBox(
 					# Translators: Text of a message dialog when updating the add-on
@@ -398,39 +396,19 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 					wx.OK | wx.ICON_INFORMATION,
 				)
 				return
-
-			# Apply update with progress
-			progress = wx.ProgressDialog(
-				# Translators: Text of a progress dialog when updating the add-on
-				_("Applying Update"),
-				# Translators: Text of a progress dialog when updating the add-on
-				_("Please wait..."),
-				maximum=100,
-				parent=self,
-				style=wx.PD_APP_MODAL | wx.PD_AUTO_HIDE,
-			)
-
-			def merge_progress(percent, message):
-				progress.Update(percent, message)
-
-			manager.smart_merge(changes, decisions, merge_progress)
-
 			progress.Destroy()
+			manager.cleanup()
 
-			# Success!
 			wx.MessageBox(
 				_(
 					# Translators: Text of a message dialog when updating the add-on
-					"Update to {latest_version} applied successfully!\n\n"
-					"Please restart NVDA for changes to take effect."
+					"Update to {latest_version} installed successfully and will be applied after NVDA restarts."
 				).format(latest_version=latest_version),
 				# Translators: Title of a message dialog when updating the add-on
 				_("Update Successful"),
 				wx.OK | wx.ICON_INFORMATION,
 			)
-
-			# Cleanup
-			manager.cleanup()
+			manager.prompt_for_restart()
 
 		except Exception as e:
 			progress.Destroy()

--- a/tests/test_addon_install_update.py
+++ b/tests/test_addon_install_update.py
@@ -1,0 +1,183 @@
+import builtins
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+
+class _FakeLog:
+	def __init__(self):
+		self.messages = []
+
+	def info(self, *args, **kwargs):
+		self.messages.append(("info", args, kwargs))
+
+	def error(self, *args, **kwargs):
+		self.messages.append(("error", args, kwargs))
+
+
+class _ModuleStubs:
+	def __init__(self, **modules):
+		self.modules = modules
+		self.original_modules = {}
+		self.original_translation = None
+		self.had_translation = False
+
+	def __enter__(self):
+		self.had_translation = hasattr(builtins, "_")
+		if self.had_translation:
+			self.original_translation = builtins._
+		builtins._ = lambda text: text
+		for name, module in self.modules.items():
+			self.original_modules[name] = sys.modules.get(name)
+			sys.modules[name] = module
+		return self
+
+	def __exit__(self, exc_type, exc, traceback):
+		for name, module in self.original_modules.items():
+			if module is None:
+				sys.modules.pop(name, None)
+			else:
+				sys.modules[name] = module
+		if self.had_translation:
+			builtins._ = self.original_translation
+		else:
+			del builtins._
+
+
+class _FakeUrlResponse:
+	def __init__(self, payload):
+		self.payload = json.dumps(payload).encode("utf-8")
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, exc_type, exc, traceback):
+		return False
+
+	def read(self):
+		return self.payload
+
+
+def _load_updater():
+	addon_handler = types.SimpleNamespace(initTranslation=lambda: None)
+	with _ModuleStubs(addonHandler=addon_handler):
+		sys.modules.pop("addon.synthDrivers._eloquence_updater", None)
+		module = importlib.import_module("addon.synthDrivers._eloquence_updater")
+		module._ = lambda text: text
+		return module
+
+
+class AddonUpdaterInstallTests(unittest.TestCase):
+	def test_check_for_updates_requires_packaged_addon_asset(self):
+		module = _load_updater()
+		payload = {
+			"tag_name": "v2",
+			"assets": [{"name": "source.zip", "browser_download_url": "https://example.test/source.zip"}],
+		}
+		module.urllib.request.urlopen = lambda req: _FakeUrlResponse(payload)
+
+		with tempfile.TemporaryDirectory() as root:
+			with open(os.path.join(root, "manifest.ini"), "w", encoding="utf-8") as manifest:
+				manifest.write("version = v1\n")
+			manager = module.EloquenceUpdateManager(os.path.join(root, "synthDrivers"))
+
+			with self.assertRaisesRegex(RuntimeError, "NVDA add-on package"):
+				manager.check_for_updates()
+
+	def test_check_for_updates_uses_nvda_addon_release_asset(self):
+		module = _load_updater()
+		payload = {
+			"tag_name": "v2",
+			"body": "Changes",
+			"assets": [
+				{"name": "source.zip", "browser_download_url": "https://example.test/source.zip"},
+				{
+					"name": "Eloquence-v2.nvda-addon",
+					"browser_download_url": "https://example.test/Eloquence.nvda-addon",
+				},
+			],
+		}
+		module.urllib.request.urlopen = lambda req: _FakeUrlResponse(payload)
+
+		with tempfile.TemporaryDirectory() as root:
+			with open(os.path.join(root, "manifest.ini"), "w", encoding="utf-8") as manifest:
+				manifest.write("version = v1\n")
+			manager = module.EloquenceUpdateManager(os.path.join(root, "synthDrivers"))
+
+			self.assertEqual(
+				manager.check_for_updates(),
+				(True, "2", "https://example.test/Eloquence.nvda-addon", "Changes"),
+			)
+
+	def test_install_update_calls_nvda_addon_store_install_api(self):
+		module = _load_updater()
+		calls = []
+		addon_store = types.ModuleType("addonStore")
+		install_module = types.ModuleType("addonStore.install")
+		install_module.installAddon = lambda addon_path: calls.append(addon_path)
+
+		with _ModuleStubs(addonStore=addon_store, **{"addonStore.install": install_module}):
+			manager = module.EloquenceUpdateManager(os.getcwd())
+
+			self.assertTrue(manager.install_update("update.nvda-addon", parent=object()))
+
+		self.assertEqual(calls, ["update.nvda-addon"])
+
+
+class InstallTasksTests(unittest.TestCase):
+	def test_on_install_preserves_existing_dic_files_only(self):
+		with tempfile.TemporaryDirectory() as root:
+			installed = os.path.join(root, "Eloquence")
+			pending = os.path.join(root, "Eloquence.pendingInstall")
+			installed_data = os.path.join(installed, "synthDrivers", "eloquence")
+			pending_data = os.path.join(pending, "synthDrivers", "eloquence")
+			os.makedirs(installed_data)
+			os.makedirs(pending_data)
+
+			with open(os.path.join(installed_data, "enumain.dic"), "w", encoding="cp1252") as dictionary:
+				dictionary.write("user dictionary")
+			with open(os.path.join(installed_data, "ECI.INI"), "w", encoding="utf-8") as ini:
+				ini.write("installed ini")
+			with open(os.path.join(installed_data, "ENU.SYN"), "w", encoding="utf-8") as voice:
+				voice.write("installed voice data")
+			with open(os.path.join(pending_data, "enumain.dic"), "w", encoding="cp1252") as dictionary:
+				dictionary.write("packaged dictionary")
+
+			addon = types.SimpleNamespace(path=pending, installPath=installed)
+			addon_handler = types.SimpleNamespace(getCodeAddon=lambda: addon)
+			fake_log = _FakeLog()
+			log_handler = types.SimpleNamespace(log=fake_log)
+
+			with _ModuleStubs(addonHandler=addon_handler, logHandler=log_handler):
+				sys.modules.pop("addon.installTasks", None)
+				install_tasks = importlib.import_module("addon.installTasks")
+				install_tasks.onInstall()
+
+			with open(os.path.join(pending_data, "enumain.dic"), encoding="cp1252") as dictionary:
+				self.assertEqual(dictionary.read(), "user dictionary")
+			self.assertFalse(os.path.exists(os.path.join(pending_data, "ECI.INI")))
+			self.assertFalse(os.path.exists(os.path.join(pending_data, "ENU.SYN")))
+
+	def test_on_install_ignores_first_install_without_existing_addon(self):
+		with tempfile.TemporaryDirectory() as root:
+			pending = os.path.join(root, "Eloquence.pendingInstall")
+			os.makedirs(os.path.join(pending, "synthDrivers", "eloquence"))
+
+			addon = types.SimpleNamespace(path=pending, installPath=os.path.join(root, "Eloquence"))
+			addon_handler = types.SimpleNamespace(getCodeAddon=lambda: addon)
+			log_handler = types.SimpleNamespace(log=_FakeLog())
+
+			with _ModuleStubs(addonHandler=addon_handler, logHandler=log_handler):
+				sys.modules.pop("addon.installTasks", None)
+				install_tasks = importlib.import_module("addon.installTasks")
+				install_tasks.onInstall()
+
+			self.assertEqual(os.listdir(os.path.join(pending, "synthDrivers", "eloquence")), [])
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Fixes #113.

## Summary
- replace the custom zip extraction/update merge with NVDA's standard add-on install path for downloaded `.nvda-addon` releases
- require GitHub releases to provide a packaged NVDA add-on asset instead of falling back to source zips
- add `installTasks.onInstall` to preserve existing `.dic` dictionary files when NVDA stages a pending add-on install
- prompt for NVDA restart after the package is installed

## Tests
- `PYTHONPATH=. ./runpytest.bat -q`
- `./runlint.bat addon/installTasks.py addon/synthDrivers/_eloquence_updater.py addon/synthDrivers/eloquence.py tests/test_addon_install_update.py`
- `python -m compileall -q addon/installTasks.py addon/synthDrivers/_eloquence_updater.py addon/synthDrivers/eloquence.py tests/test_addon_install_update.py`