### PR TITLE
fix: remove duplicate add-on update success notice (#116)

### DIFF
--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -398,16 +398,6 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 				return
 			progress.Destroy()
 			manager.cleanup()
-
-			wx.MessageBox(
-				_(
-					# Translators: Text of a message dialog when updating the add-on
-					"Update to {latest_version} installed successfully and will be applied after NVDA restarts."
-				).format(latest_version=latest_version),
-				# Translators: Title of a message dialog when updating the add-on
-				_("Update Successful"),
-				wx.OK | wx.ICON_INFORMATION,
-			)
 			manager.prompt_for_restart()
 
 		except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #116 — a single add-on update produced two notices.

The settings panel showed a custom "Update Successful" message box and then NVDA emitted its own add-on-changed restart notice. This removes the custom message box so users see only NVDA's standard restart prompt (via `manager.prompt_for_restart()`), which is the canonical "changes will apply after restart" notification.

## Change

- Delete the redundant `wx.MessageBox` success notice in `EloquenceSettingsPanel.onCheckAddonUpdate`.

## Notes

Pure deletion on the success path; the error/cancelled/no-update branches are unchanged. No test added — the change is a one-line removal of a cosmetic dialog that's verified by running the updater.
