### PR TITLE
docs: define Script Conversion and record ADR 0001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,10 @@ _Avoid_: sanitization, normalization, regex fixes
 The character encoding used when sending Eloquence Text bytes to the Eloquence Engine for the active Voice Identity.
 _Avoid_: MBCS, language encoding, current lang
 
+**Script Conversion**:
+The Traditional-to-Simplified Chinese transformation applied during Text Preprocessing whenever the Mandarin Chinese Voice Identity is active, so Traditional-script text is pronounceable by the Simplified-only engine data.
+_Avoid_: T2S, fallback, traditional fallback, OpenCC conversion, CHS fallback
+
 ### Voice Model
 
 **Voice Identity**:

--- a/docs/adr/0001-script-conversion-for-traditional-chinese.md
+++ b/docs/adr/0001-script-conversion-for-traditional-chinese.md
@@ -1,0 +1,16 @@
+# Read Traditional Chinese via Script Conversion on the Mandarin voice
+
+The Eloquence Engine's only Chinese data (`chs.syn`) is Simplified-script Mandarin; it cannot pronounce Traditional-exclusive characters (issue #98). We decided to apply phrase-aware Traditional-to-Simplified Script Conversion during Text Preprocessing — unconditionally, whenever the Mandarin Chinese Voice Identity is active — using vendored OpenCC data tables and a small in-repo longest-match converter.
+
+## Considered Options
+
+- **A real Traditional Chinese voice** (`eciTaiwaneseMandarin`, 0x60001): the ECI API defines it and IBM shipped it, but the engine data (`cht50.syn`) is lost — the NVDA community has searched and never found a copy (NVDA-IBMTTS-Driver #57). Not possible.
+- **Cantonese voice data** (`ctt`, 0xB0001, Big5): circulates informally but has murky provenance, and Cantonese is a different spoken language — it would not serve Taiwanese users, who want Mandarin. Out of scope; documented as a known limitation for Hong Kong users.
+- **Convert only when zh-TW/zh-Hant is requested**: rejected — document language tags are unreliable, and issue #98's text arrived untagged. Conversion is a near-no-op on Simplified text, so running it unconditionally on the Mandarin path is safe and simpler.
+- **Vendor a conversion library** (opencc-python-reimplemented, zhconv): rejected — the linguistic knowledge is in OpenCC's ~40 KB of data tables; the matching algorithm is ~30 lines. We ship the tables verbatim (auditable against upstream, Apache-2.0) and own the matcher.
+
+## Consequences
+
+- Traditional Chinese is read with Mandarin pronunciation and mainland lexicon; correct for Taiwanese users, a better-than-nothing fallback for Hong Kong users (no Cantonese). Colloquial written-Cantonese characters remain unpronounceable.
+- The voice list still advertises only `zh-CN`; zh-TW-localized NVDA does not auto-select the Chinese voice on first run.
+- There is no user setting: Script Conversion is in the same category as the unconditional crash-prevention fixes.


### PR DESCRIPTION
Documentation only — no code changes.

- Adds the **Script Conversion** term to the `CONTEXT.md` glossary (the Traditional-to-Simplified Chinese transformation applied during Text Preprocessing for the Mandarin Chinese Voice Identity).
- Records ADR 0001: why Traditional Chinese is read via Script Conversion on the Mandarin voice rather than a Traditional voice (the `cht50.syn` engine data is lost) or Cantonese data (different spoken language, murky provenance).

These docs are referenced by #118 and #119 and provide the context for resolving #98.