### PR TITLE
[codex] Fix secure-screen Eloquence copy

### DIFF
--- a/addon/synthDrivers/_secure_screen.py
+++ b/addon/synthDrivers/_secure_screen.py
@@ -1,0 +1,59 @@
+"""Helpers for installing Eloquence resources into NVDA's system configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+HOST_EXECUTABLE = "eloquence_host32.exe"
+ECI_INI = "ECI.INI"
+
+
+@dataclass(frozen=True)
+class SecureScreenCopyPlan:
+	command: str
+	source_host: str
+	source_ini: str
+	dest_host: str
+	dest_ini: str
+
+
+def read_manifest_version(addon_dir: str) -> str | None:
+	manifest_path = os.path.join(addon_dir, "manifest.ini")
+	try:
+		with open(manifest_path, encoding="utf-8") as manifest:
+			for line in manifest:
+				key, separator, value = line.partition("=")
+				if separator and key.strip().lower() == "version":
+					return value.strip()
+	except OSError:
+		return None
+	return None
+
+
+def build_copy_plan(source_synth_dir: str, target_addon_dir: str) -> SecureScreenCopyPlan:
+	source_host = os.path.normpath(os.path.join(source_synth_dir, HOST_EXECUTABLE))
+	source_ini = os.path.normpath(os.path.join(source_synth_dir, "eloquence", ECI_INI))
+	dest_synth_dir = os.path.normpath(os.path.join(target_addon_dir, "synthDrivers"))
+	dest_eloquence_dir = os.path.normpath(os.path.join(dest_synth_dir, "eloquence"))
+	dest_host = os.path.normpath(os.path.join(dest_synth_dir, HOST_EXECUTABLE))
+	dest_ini = os.path.normpath(os.path.join(dest_eloquence_dir, ECI_INI))
+
+	for required_path in (source_host, source_ini):
+		if not os.path.exists(required_path):
+			raise FileNotFoundError(required_path)
+
+	command = (
+		f'/d /c if not exist "{dest_synth_dir}" mkdir "{dest_synth_dir}"'
+		f' && if not exist "{dest_eloquence_dir}" mkdir "{dest_eloquence_dir}"'
+		f' && copy /y "{source_host}" "{dest_host}" >nul'
+		f' && copy /y "{source_ini}" "{dest_ini}" >nul'
+	)
+	return SecureScreenCopyPlan(
+		command=command,
+		source_host=source_host,
+		source_ini=source_ini,
+		dest_host=dest_host,
+		dest_ini=dest_ini,
+	)

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -65,6 +65,7 @@ from synthDriverHandler import (
 	synthIndexReached,
 	synthDoneSpeaking,
 )
+from . import _secure_screen
 from . import _eloquence
 from . import _text_preprocessing
 from collections import OrderedDict
@@ -74,6 +75,54 @@ import addonHandler
 addonHandler.initTranslation()
 
 log = logging.getLogger(__name__)
+
+
+SEE_MASK_NOCLOSEPROCESS = 0x00000040
+INFINITE = 0xFFFFFFFF
+ERROR_CANCELLED = 1223
+SE_ERR_ACCESSDENIED = 5
+
+
+class _ShellExecuteInfo(ctypes.Structure):
+	_fields_ = [
+		("cbSize", ctypes.wintypes.DWORD),
+		("fMask", ctypes.wintypes.ULONG),
+		("hwnd", ctypes.wintypes.HWND),
+		("lpVerb", ctypes.wintypes.LPCWSTR),
+		("lpFile", ctypes.wintypes.LPCWSTR),
+		("lpParameters", ctypes.wintypes.LPCWSTR),
+		("lpDirectory", ctypes.wintypes.LPCWSTR),
+		("nShow", ctypes.c_int),
+		("hInstApp", ctypes.wintypes.HINSTANCE),
+		("lpIDList", ctypes.c_void_p),
+		("lpClass", ctypes.wintypes.LPCWSTR),
+		("hkeyClass", ctypes.wintypes.HKEY),
+		("dwHotKey", ctypes.wintypes.DWORD),
+		("hIcon", ctypes.wintypes.HANDLE),
+		("hProcess", ctypes.wintypes.HANDLE),
+	]
+
+
+def _run_elevated_command(command_params):
+	execute_info = _ShellExecuteInfo()
+	execute_info.cbSize = ctypes.sizeof(execute_info)
+	execute_info.fMask = SEE_MASK_NOCLOSEPROCESS
+	execute_info.lpVerb = "runas"
+	execute_info.lpFile = "cmd.exe"
+	execute_info.lpParameters = command_params
+	execute_info.nShow = 0
+
+	if not ctypes.windll.shell32.ShellExecuteExW(ctypes.byref(execute_info)):
+		return False, ctypes.windll.kernel32.GetLastError()
+
+	try:
+		ctypes.windll.kernel32.WaitForSingleObject(execute_info.hProcess, INFINITE)
+		exit_code = ctypes.wintypes.DWORD()
+		ctypes.windll.kernel32.GetExitCodeProcess(execute_info.hProcess, ctypes.byref(exit_code))
+		return exit_code.value == 0, exit_code.value
+	finally:
+		if execute_info.hProcess:
+			ctypes.windll.kernel32.CloseHandle(execute_info.hProcess)
 
 
 minRate = 40
@@ -175,8 +224,9 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 			# Panel creation failed, but don't crash - synth will still work
 
 	def onCopyHelper(self, evt):
-		"""Copies eloquence_host32.exe with UAC elevation support and definitive feedback."""
-		source_file = os.path.normpath(os.path.join(os.path.dirname(__file__), "eloquence_host32.exe"))
+		"""Copies secure-screen runtime files with UAC elevation support and definitive feedback."""
+		source_synth_dir = os.path.abspath(os.path.dirname(__file__))
+		source_addon_dir = os.path.abspath(os.path.join(source_synth_dir, os.pardir))
 		prog_files = os.environ.get("ProgramFiles", "C:\\Program Files")
 		target_addon_dir = os.path.normpath(
 			os.path.join(prog_files, "NVDA", "systemConfig", "addons", "Eloquence")
@@ -195,39 +245,56 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 			)
 			return
 
-		dest_dir = os.path.normpath(os.path.join(target_addon_dir, "synthDrivers"))
-		dest_file = os.path.normpath(os.path.join(dest_dir, "eloquence_host32.exe"))
+		source_version = _secure_screen.read_manifest_version(source_addon_dir)
+		target_version = _secure_screen.read_manifest_version(target_addon_dir)
+		if not source_version or not target_version or source_version != target_version:
+			wx.MessageBox(
+				_(
+					# Translators: Text of a message dialog when copying helper files to system config
+					"The Eloquence add-on in NVDA's system configuration is not the same version as your current add-on.\n\n"
+					"Current add-on: {source_version}\n"
+					"System configuration: {target_version}\n\n"
+					"Go to NVDA Settings > General, run 'Use currently saved settings during sign-in', "
+					"select Eloquence, then return here and run this copy again."
+				).format(
+					source_version=source_version or _("unknown"),
+					target_version=target_version or _("unknown"),
+				),
+				# Translators: Title of a message dialog when copying helper files to system config
+				_("System Configuration Copy Is Outdated"),
+				wx.OK | wx.ICON_WARNING,
+			)
+			return
 
-		if not os.path.exists(source_file):
+		try:
+			copy_plan = _secure_screen.build_copy_plan(source_synth_dir, target_addon_dir)
+		except FileNotFoundError as e:
 			wx.MessageBox(
 				# Translators: Text of a message dialog when copying the helper to system config
-				_("Source file not found at:\n{source_file}").format(source_file=source_file),
+				_("Source file not found at:\n{source_file}").format(source_file=str(e)),
 				# Translators: Title of a message dialog when copying the helper to system config
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 			)
 			return
 
-		# Prepare elevated command: ensure subdirectory exists and copy the helper
-		cmd_params = f'/c mkdir "{dest_dir}" 2>nul & copy /y "{source_file}" "{dest_file}"'
-
 		try:
-			# Triggering UAC Elevation using ShellExecuteW's "runas" verb
-			ret = ctypes.windll.shell32.ShellExecuteW(None, "runas", "cmd.exe", cmd_params, None, 0)
+			success, ret = _run_elevated_command(copy_plan.command)
 
-			if ret > 32:
+			if success:
 				# Play Windows Asterisk sound for confirmation of successful launch
 				winsound.MessageBeep(winsound.MB_ICONASTERISK)
 				wx.MessageBox(
 					_(
 						# Translators: text of a message dialog when copying the helper to system config
-						"Successfully copied eloquence_host32.exe to systemConfig!\n\nEloquence should now load normally on logon screen, start-up, and other secure screens."
+						"Successfully copied Eloquence secure-screen files to systemConfig!\n\n"
+						"Eloquence should now load normally on logon screen, start-up, and other secure screens."
 					),
 					# Translators: Title of a message dialog when copying the helper to system config
 					_("Success"),
 					wx.OK | wx.ICON_INFORMATION,
 				)
-			elif ret == 5:
+			elif ret in (SE_ERR_ACCESSDENIED, ERROR_CANCELLED):
 				# SE_ERR_ACCESSDENIED: Elevation prompt was declined
 				wx.MessageBox(
 					# Translators: Text of a message dialog when copying the helper to system config

--- a/host_eloquence32.py
+++ b/host_eloquence32.py
@@ -20,6 +20,7 @@ import pickle
 import socket
 import struct
 import sys
+import tempfile
 import threading
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "eloquence"))
@@ -96,6 +97,59 @@ def get_short_path(path):
 			buf_size = needed
 	except Exception:
 		return path
+
+
+def _split_line_ending(line: str) -> tuple[str, str]:
+	if line.endswith("\r\n"):
+		return line[:-2], "\r\n"
+	if line.endswith("\n"):
+		return line[:-1], "\n"
+	return line, ""
+
+
+def _rewrite_eci_ini_paths(ini_content: str, eloquence_dir: str) -> str:
+	if not ini_content.strip():
+		raise RuntimeError(
+			"ECI.INI is empty. Re-copy Eloquence to NVDA's system configuration before using secure screens."
+		)
+
+	short_eloquence_dir = get_short_path(eloquence_dir)
+	rewritten_lines = []
+	for line in ini_content.splitlines(keepends=True):
+		body, line_ending = _split_line_ending(line)
+		stripped = body.lstrip()
+		indent = body[: len(body) - len(stripped)]
+		for key in ("Path", "Path_Rom"):
+			prefix = f"{key}="
+			if stripped.startswith(prefix):
+				source_path = stripped[len(prefix) :].strip()
+				filename = source_path.rstrip("\\/").replace("/", "\\").rsplit("\\", 1)[-1]
+				if filename:
+					rewritten_lines.append(f"{indent}{key}={short_eloquence_dir}\\{filename}{line_ending}")
+					break
+		else:
+			rewritten_lines.append(line.replace("C:\\dummy\\", short_eloquence_dir + "\\"))
+	return "".join(rewritten_lines)
+
+
+def _write_text_atomic(path: str, content: str) -> None:
+	directory = os.path.dirname(path)
+	fd, temp_path = tempfile.mkstemp(
+		prefix=f".{os.path.basename(path)}.",
+		suffix=".tmp",
+		dir=directory,
+		text=True,
+	)
+	try:
+		with os.fdopen(fd, "w", encoding="utf-8", newline="") as temp_file:
+			temp_file.write(content)
+		os.replace(temp_path, path)
+	except Exception:
+		try:
+			os.unlink(temp_path)
+		except OSError:
+			pass
+		raise
 
 
 # Constants mirrored from the old in-process implementation.
@@ -230,18 +284,13 @@ class EloquenceRuntime:
 		ini_path = self._config.eci_path[:-3] + "ini"
 		eloquence_dir = os.path.dirname(self._config.eci_path)
 
-		# Read the entire INI file
+		# Ensure ECI.INI points at this install without risking a truncated file
+		# if the secure-screen host is interrupted during startup.
 		with open(ini_path, "r", encoding="utf-8") as f:
 			ini_content = f.read()
-
-		# Replace C:\dummy\ with the actual eloquence directory
-		# Use short path to avoid encoding issues with legacy DLLs and Python's default encoding
-		short_eloquence_dir = get_short_path(eloquence_dir)
-		updated_content = ini_content.replace("C:\\dummy\\", short_eloquence_dir + "\\")
-
-		# Write the updated content back
-		with open(ini_path, "w", encoding="utf-8") as f:
-			f.write(updated_content)
+		updated_content = _rewrite_eci_ini_paths(ini_content, eloquence_dir)
+		if updated_content != ini_content:
+			_write_text_atomic(ini_path, updated_content)
 		self._dll = ctypes.windll.LoadLibrary(self._config.eci_path)
 		self._dll.eciRegisterCallback.argtypes = [c_void_p, Callback, c_void_p]
 		self._dll.eciRegisterCallback.restype = None
@@ -294,7 +343,9 @@ class EloquenceRuntime:
 					path = os.path.join(dictionary_dir, candidate)
 					if os.path.exists(path):
 						# LOGGER.debug("Loading dictionary index=%s file=%s", index, path)
-						self._dll.eciLoadDict(self._handle, self._dictionary_handle, index, path.encode("mbcs"))
+						self._dll.eciLoadDict(
+							self._handle, self._dictionary_handle, index, path.encode("mbcs")
+						)
 						break
 			self._loaded_dictionary_languages.add(language_code)
 		self._dll.eciSetDict(self._handle, self._dictionary_handle)

--- a/tests/test_secure_screen_install.py
+++ b/tests/test_secure_screen_install.py
@@ -1,0 +1,81 @@
+import os
+import tempfile
+import unittest
+
+import host_eloquence32 as host
+from addon.synthDrivers import _secure_screen
+
+
+class HostEciIniTests(unittest.TestCase):
+	def test_rewrite_eci_ini_paths_updates_existing_and_dummy_paths(self):
+		original_get_short_path = host.get_short_path
+		host.get_short_path = (
+			lambda path: r"C:\Program Files\NVDA\systemConfig\addons\Eloquence\synthDrivers\eloquence"
+		)
+		try:
+			content = (
+				"[7.0]\n"
+				r"Path=C:\Users\andrew\AppData\Roaming\nvda\addons\ELOQUE~1\SYNTHD~1\ELOQUE~1\ptb.syn"
+				"\n"
+				r"Path_Rom=C:\dummy\jpnrom.dll"
+				"\n"
+				r"Other=C:\dummy\untouched.dat"
+				"\n"
+			)
+
+			rewritten = host._rewrite_eci_ini_paths(content, r"C:\ignored")
+		finally:
+			host.get_short_path = original_get_short_path
+
+		self.assertIn(
+			r"Path=C:\Program Files\NVDA\systemConfig\addons\Eloquence\synthDrivers\eloquence\ptb.syn",
+			rewritten,
+		)
+		self.assertIn(
+			r"Path_Rom=C:\Program Files\NVDA\systemConfig\addons\Eloquence\synthDrivers\eloquence\jpnrom.dll",
+			rewritten,
+		)
+		self.assertIn(
+			r"Other=C:\Program Files\NVDA\systemConfig\addons\Eloquence\synthDrivers\eloquence\untouched.dat",
+			rewritten,
+		)
+		self.assertNotIn(r"C:\Users\andrew\AppData", rewritten)
+		self.assertNotIn(r"C:\dummy", rewritten)
+
+	def test_rewrite_eci_ini_paths_rejects_empty_ini(self):
+		with self.assertRaisesRegex(RuntimeError, "ECI.INI is empty"):
+			host._rewrite_eci_ini_paths("", r"C:\Program Files\NVDA\systemConfig")
+
+
+class SecureScreenCopyPlanTests(unittest.TestCase):
+	def test_read_manifest_version(self):
+		with tempfile.TemporaryDirectory() as root:
+			with open(os.path.join(root, "manifest.ini"), "w", encoding="utf-8") as manifest:
+				manifest.write("name = Eloquence\nversion = v18\n")
+
+			self.assertEqual(_secure_screen.read_manifest_version(root), "v18")
+
+	def test_build_copy_plan_includes_host_and_eci_ini(self):
+		with tempfile.TemporaryDirectory() as root:
+			source_synth = os.path.join(root, "source", "synthDrivers")
+			source_eci = os.path.join(source_synth, "eloquence")
+			target_addon = os.path.join(root, "systemConfig", "addons", "Eloquence")
+			os.makedirs(source_eci)
+			os.makedirs(target_addon)
+			with open(os.path.join(source_synth, "eloquence_host32.exe"), "w", encoding="utf-8") as host_exe:
+				host_exe.write("host")
+			with open(os.path.join(source_eci, "ECI.INI"), "w", encoding="utf-8") as ini:
+				ini.write("[7.0]\n")
+
+			plan = _secure_screen.build_copy_plan(source_synth, target_addon)
+
+		self.assertTrue(plan.source_host.endswith(os.path.join("synthDrivers", "eloquence_host32.exe")))
+		self.assertTrue(plan.source_ini.endswith(os.path.join("synthDrivers", "eloquence", "ECI.INI")))
+		self.assertTrue(plan.dest_host.endswith(os.path.join("synthDrivers", "eloquence_host32.exe")))
+		self.assertTrue(plan.dest_ini.endswith(os.path.join("synthDrivers", "eloquence", "ECI.INI")))
+		self.assertIn("eloquence_host32.exe", plan.command)
+		self.assertIn("ECI.INI", plan.command)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- prevent the secure-screen helper copy from mixing a current helper executable into an outdated systemConfig add-on copy
- copy the packaged ECI.INI alongside the helper executable so secure screens do not keep a stale or empty INI
- make host-side ECI.INI rewriting reject empty files and write updates atomically

## Root cause
NVDA's secure-screen configuration can contain an older add-on copy than the user's current add-on. The existing helper button only copied eloquence_host32.exe, so it could leave old Python files and stale or empty ECI.INI data in systemConfig. The host also rewrote ECI.INI in place during startup, which made a truncated INI a persistent secure-screen failure.

## Verification
- `PYTHONPATH=. py -3 -m pytest` -> 28 passed
- `py -3 -m ruff check addon/synthDrivers/_secure_screen.py addon/synthDrivers/eloquence.py host_eloquence32.py tests/test_secure_screen_install.py`
- `py -3 -m ruff format --check addon/synthDrivers/_secure_screen.py addon/synthDrivers/eloquence.py host_eloquence32.py tests/test_secure_screen_install.py`
- `build_host.cmd`
- `scons.bat` -> generated `Eloquence-v18-7-g57c4647.nvda-addon` and confirmed it contains `synthDrivers/_secure_screen.py`, `synthDrivers/eloquence_host32.exe`, and `synthDrivers/eloquence/ECI.INI`
