### PR TITLE
Fix Say-All stalls after phrase-final em dash

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -32,10 +32,6 @@ class AudioWorker(threading.Thread):
 	_CHANNELS = 1
 	_BITS_PER_SAMPLE = 16
 	_SAMPLE_RATE = 11025
-	# One silent 16-bit mono sample.  Queueing this with an onDone callback
-	# places an index precisely after preceding audio without blocking the
-	# worker and starving WavePlayer's buffer.
-	_INDEX_MARKER_AUDIO = b"\x00\x00"
 
 	def __init__(
 		self,
@@ -68,10 +64,7 @@ class AudioWorker(threading.Thread):
 			if not data:
 				if not self._stopping:
 					if index is not None:
-						# The host emits indexes as separate zero-length chunks.
-						# Queue a silent sample so WavePlayer invokes the callback
-						# after preceding audio, while later audio can still be fed.
-						self._queue_index_marker(index)
+						self._invoke_index_callback(index)
 					if is_final:
 						self._schedule_idle()
 				self._queue.task_done()
@@ -132,18 +125,6 @@ class AudioWorker(threading.Thread):
 			LOGGER.exception("WavePlayer idle failed")
 		if not self._stopping:
 			self._invoke_index_callback(None)
-
-	def _queue_index_marker(self, index: int) -> None:
-		"""Queue a non-blocking playback marker for a Speech Index."""
-		try:
-			with self._player_lock:
-				if not self._stopping and self._player:
-					self._player.feed(
-						self._INDEX_MARKER_AUDIO,
-						onDone=lambda: self._invoke_index_callback(index),
-					)
-		except Exception:
-			LOGGER.exception("WavePlayer index marker feed failed")
 
 	def _invoke_index_callback(self, value: Optional[int]) -> None:
 		global lastindex

--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -32,6 +32,10 @@ class AudioWorker(threading.Thread):
 	_CHANNELS = 1
 	_BITS_PER_SAMPLE = 16
 	_SAMPLE_RATE = 11025
+	# One silent 16-bit mono sample.  Queueing this with an onDone callback
+	# places an index precisely after preceding audio without blocking the
+	# worker and starving WavePlayer's buffer.
+	_INDEX_MARKER_AUDIO = b"\x00\x00"
 
 	def __init__(
 		self,
@@ -64,7 +68,10 @@ class AudioWorker(threading.Thread):
 			if not data:
 				if not self._stopping:
 					if index is not None:
-						self._invoke_index_callback(index)
+						# The host emits indexes as separate zero-length chunks.
+						# Queue a silent sample so WavePlayer invokes the callback
+						# after preceding audio, while later audio can still be fed.
+						self._queue_index_marker(index)
 					if is_final:
 						self._schedule_idle()
 				self._queue.task_done()
@@ -125,6 +132,18 @@ class AudioWorker(threading.Thread):
 			LOGGER.exception("WavePlayer idle failed")
 		if not self._stopping:
 			self._invoke_index_callback(None)
+
+	def _queue_index_marker(self, index: int) -> None:
+		"""Queue a non-blocking playback marker for a Speech Index."""
+		try:
+			with self._player_lock:
+				if not self._stopping and self._player:
+					self._player.feed(
+						self._INDEX_MARKER_AUDIO,
+						onDone=lambda: self._invoke_index_callback(index),
+					)
+		except Exception:
+			LOGGER.exception("WavePlayer index marker feed failed")
 
 	def _invoke_index_callback(self, value: Optional[int]) -> None:
 		global lastindex

--- a/addon/synthDrivers/_text_preprocessing.py
+++ b/addon/synthDrivers/_text_preprocessing.py
@@ -12,6 +12,14 @@ import unicodedata
 
 from ._script_conversion import convert_traditional_to_simplified
 
+
+# Eloquence can finish synthesis without delivering a following Speech Index
+# when an em dash is the final punctuation in a text block.  A comma preserves
+# the intended phrase break without exposing the legacy parser to U+2014 in
+# this position.  Include common closing quotes/brackets in the lookahead
+# because NVDA's symbol processing may preserve or remove them.
+_PHRASE_FINAL_EM_DASH = re.compile(r"\u2014(?=[\"'\u2019\u201d)\]}]*\s*$)")
+
 # ---------------------------------------------------------------------------
 # Crash prevention dictionaries
 # ---------------------------------------------------------------------------
@@ -195,6 +203,7 @@ def _resub(dct, s):
 # ---------------------------------------------------------------------------
 def preprocess(text, voice_id):
 	"""Apply crash prevention fixes and text normalization for *voice_id*."""
+	text = _PHRASE_FINAL_EM_DASH.sub(",", text)
 	# CHS and KOR get English fixes (they render embedded English text)
 	if voice_id in _ENGLISH_IDS + _CHINESE_ID + _KOREAN_ID:
 		text = _resub(english_fixes, text)

--- a/host_eloquence32.py
+++ b/host_eloquence32.py
@@ -205,6 +205,7 @@ class EloquenceRuntime:
 		self._voice_params: Dict[int, int] = {}
 		self._speaking = False
 		self._saw_final_index = False
+		self._pending_indexes: list[int] = []
 
 	# ------------------------------------------------------------------
 	# Communication helpers
@@ -308,6 +309,8 @@ class EloquenceRuntime:
 	def insert_index(self, index: int) -> None:
 		# LOGGER.debug("Inserting index %s", index)
 		self._dll.eciInsertIndex(self._handle, index)
+		if index != FINAL_INDEX:
+			self._pending_indexes.append(index)
 
 	def synthesize(self) -> None:
 		# LOGGER.debug("Starting synthesis")
@@ -325,6 +328,7 @@ class EloquenceRuntime:
 			# If no final index was delivered, still emit a final marker so NVDA
 			# receives synthDoneSpeaking (e.g. when there is no text to speak).
 			if not self._saw_final_index:
+				self._report_latest_pending_index()
 				self._send_event("audio", data=b"", index=None, final=True)
 
 	def stop(self) -> None:
@@ -332,6 +336,7 @@ class EloquenceRuntime:
 		self._dll.eciStop(self._handle)
 		self._audio_buffer.seek(0)
 		self._audio_buffer.truncate(0)
+		self._pending_indexes.clear()
 		self._speaking = False
 		self._send_event("stopped")
 
@@ -392,12 +397,41 @@ class EloquenceRuntime:
 			# Index callback
 			is_final = length == FINAL_INDEX
 			index_value = length if not is_final else None
+			if is_final:
+				self._report_latest_pending_index()
+			else:
+				self._discard_pending_indexes_through(length)
 			# Send empty chunk with index marker
 			self._send_event("audio", data=b"", index=index_value, final=is_final)
 			if is_final:
 				self._saw_final_index = True
 				self._speaking = False
 		return 1
+
+	def _discard_pending_indexes_through(self, index: int) -> None:
+		"""Forget indexes at or before an index reported by the engine.
+
+		NVDA treats an observed later Speech Index as evidence that earlier
+		indexes with no intervening audio were also reached.  Mirroring that rule
+		here prevents an older skipped index from being reported out of order at
+		final completion.
+		"""
+		try:
+			position = self._pending_indexes.index(index)
+		except ValueError:
+			return
+		del self._pending_indexes[: position + 1]
+
+	def _report_latest_pending_index(self) -> None:
+		"""Report the latest index if the engine silently skipped its callback."""
+		if not self._pending_indexes:
+			return
+		index = self._pending_indexes[-1]
+		self._pending_indexes.clear()
+		# Host logging intentionally records errors only.  Treat this protocol
+		# recovery as an error so a silent engine failure leaves diagnostics.
+		LOGGER.error("Eloquence skipped index callback %s; reporting it at completion", index)
+		self._send_event("audio", data=b"", index=index, final=False)
 
 	def _flush_audio(self, index: Optional[int] = None, force: bool = False, final: bool = False) -> None:
 		if self._audio_buffer.tell() == 0:

--- a/tests/test_audio_worker.py
+++ b/tests/test_audio_worker.py
@@ -1,0 +1,77 @@
+import importlib.util
+import queue
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_client_module():
+	config_module = types.ModuleType("config")
+	config_module.conf = {}
+	nvwave_module = types.ModuleType("nvwave")
+	nvwave_module.WavePlayer = object
+	build_version_module = types.ModuleType("buildVersion")
+	build_version_module.version_year = 2026
+
+	stubs = {
+		"config": config_module,
+		"nvwave": nvwave_module,
+		"buildVersion": build_version_module,
+	}
+	previous = {name: sys.modules.get(name) for name in stubs}
+	sys.modules.update(stubs)
+	module_name = "addon.synthDrivers._eloquence_audio_test"
+	try:
+		path = Path(__file__).parents[1] / "addon" / "synthDrivers" / "_eloquence.py"
+		spec = importlib.util.spec_from_file_location(module_name, path)
+		module = importlib.util.module_from_spec(spec)
+		sys.modules[module_name] = module
+		spec.loader.exec_module(module)
+		return module
+	finally:
+		sys.modules.pop(module_name, None)
+		for name, old_module in previous.items():
+			if old_module is None:
+				sys.modules.pop(name, None)
+			else:
+				sys.modules[name] = old_module
+
+
+class FakePlayer:
+	def __init__(self, events):
+		self.events = events
+		self.marker_callback = None
+
+	def feed(self, data, onDone=None):
+		self.events.append(("feed", data))
+		if onDone:
+			self.marker_callback = onDone
+
+
+class FakeClient:
+	_sequence = 0
+
+
+class AudioWorkerTests(unittest.TestCase):
+	def test_empty_index_marker_queues_non_blocking_playback_callback(self):
+		module = _load_client_module()
+		events = []
+		module.onIndexReached = lambda index: events.append(("index", index))
+		audio_queue = queue.Queue()
+		audio_queue.put((b"audio", None, False, 0))
+		audio_queue.put((b"", 42, False, 0))
+		audio_queue.put(None)
+		player = FakePlayer(events)
+		worker = module.AudioWorker(player, audio_queue, FakeClient())
+
+		worker.run()
+
+		self.assertEqual(events, [("feed", b"audio"), ("feed", b"\x00\x00")])
+		self.assertIsNotNone(player.marker_callback)
+		player.marker_callback()
+		self.assertEqual(events[-1], ("index", 42))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_audio_worker.py
+++ b/tests/test_audio_worker.py
@@ -41,12 +41,9 @@ def _load_client_module():
 class FakePlayer:
 	def __init__(self, events):
 		self.events = events
-		self.marker_callback = None
 
 	def feed(self, data, onDone=None):
 		self.events.append(("feed", data))
-		if onDone:
-			self.marker_callback = onDone
 
 
 class FakeClient:
@@ -54,7 +51,9 @@ class FakeClient:
 
 
 class AudioWorkerTests(unittest.TestCase):
-	def test_empty_index_marker_queues_non_blocking_playback_callback(self):
+	def test_empty_index_chunk_fires_callback_without_feeding_player(self):
+		# Index-only chunks must never reach WavePlayer.feed: degenerate
+		# tiny buffers can cause audible clicks on some devices (see #127).
 		module = _load_client_module()
 		events = []
 		module.onIndexReached = lambda index: events.append(("index", index))
@@ -67,10 +66,7 @@ class AudioWorkerTests(unittest.TestCase):
 
 		worker.run()
 
-		self.assertEqual(events, [("feed", b"audio"), ("feed", b"\x00\x00")])
-		self.assertIsNotNone(player.marker_callback)
-		player.marker_callback()
-		self.assertEqual(events[-1], ("index", 42))
+		self.assertEqual(events, [("feed", b"audio"), ("index", 42)])
 
 
 if __name__ == "__main__":

--- a/tests/test_host_dictionaries.py
+++ b/tests/test_host_dictionaries.py
@@ -25,13 +25,24 @@ class FakeDll:
 	def eciSetParam(self, handle, param_id, value):
 		self.calls.append(("setParam", handle, param_id, value))
 
+	def eciInsertIndex(self, handle, index):
+		self.calls.append(("insertIndex", handle, index))
+
 	def eciGetVoiceParam(self, handle, voice, param_id):
 		return param_id
 
 
-def make_runtime(data_directory, language_code="enu"):
+class RecordingConnection:
+	def __init__(self):
+		self.messages = []
+
+	def send(self, message):
+		self.messages.append(message)
+
+
+def make_runtime(data_directory, language_code="enu", conn=None):
 	runtime = host.EloquenceRuntime(
-		conn=None,
+		conn=conn,
 		config=host.HostConfig(
 			eci_path="",
 			data_directory=data_directory,
@@ -44,6 +55,59 @@ def make_runtime(data_directory, language_code="enu"):
 	runtime._dll = FakeDll()
 	runtime._handle = "eci"
 	return runtime
+
+
+class SpeechIndexTests(unittest.TestCase):
+	def test_final_index_reports_latest_engine_skipped_index(self):
+		connection = RecordingConnection()
+		runtime = make_runtime("", conn=connection)
+		runtime.insert_index(41)
+		runtime.insert_index(42)
+		runtime._speaking = True
+
+		runtime._on_callback(None, 2, host.FINAL_INDEX, None)
+
+		self.assertEqual(
+			connection.messages,
+			[
+				{
+					"type": "event",
+					"event": "audio",
+					"payload": {"data": b"", "index": 42, "final": False},
+				},
+				{
+					"type": "event",
+					"event": "audio",
+					"payload": {"data": b"", "index": None, "final": True},
+				},
+			],
+		)
+
+	def test_reached_index_clears_it_and_any_skipped_predecessors(self):
+		connection = RecordingConnection()
+		runtime = make_runtime("", conn=connection)
+		runtime.insert_index(41)
+		runtime.insert_index(42)
+		runtime._speaking = True
+
+		runtime._on_callback(None, 2, 42, None)
+		runtime._on_callback(None, 2, host.FINAL_INDEX, None)
+
+		self.assertEqual(
+			connection.messages,
+			[
+				{
+					"type": "event",
+					"event": "audio",
+					"payload": {"data": b"", "index": 42, "final": False},
+				},
+				{
+					"type": "event",
+					"event": "audio",
+					"payload": {"data": b"", "index": None, "final": True},
+				},
+			],
+		)
 
 
 class DictionaryLoadingTests(unittest.TestCase):

--- a/tests/test_text_preprocessing.py
+++ b/tests/test_text_preprocessing.py
@@ -4,6 +4,9 @@ from addon.synthDrivers._text_preprocessing import preprocess
 
 
 class TextPreprocessingTests(unittest.TestCase):
+	def test_phrase_final_em_dash_is_rewritten_for_legacy_engine(self):
+		self.assertEqual(preprocess("You don't have to—  ", 65536), "You don't have to,  ")
+
 	def test_chs_preprocessing_rewrites_known_traditional_characters(self):
 		self.assertEqual(preprocess("選設檢", 393216), "选设检")
 


### PR DESCRIPTION
## Summary

- rewrite phrase-final U+2014 em dashes to a legacy-engine-safe pause
- track Speech Indexes in the 32-bit Eloquence Host Process and report the latest one at completion if the engine silently skips its callback
- queue a one-sample WavePlayer marker so Speech Progress Notifications occur after preceding audio without blocking the audio worker
- add regression coverage for preprocessing, skipped indexes, and non-blocking audio/index ordering

Fixes #111.

## Reproduction and cause

With rendered Markdown containing `"You don't have to—"`, Say-All stopped before the next paragraph. NVDA debug logging showed that the Synth Driver received `IndexCommand(5544)` with that text and later emitted `synthDoneSpeaking`, but never emitted `synthIndexReached(5544)`. NVDA therefore kept the next paragraph queued indefinitely.

This confirms the U+2014/U+201D rendered-paragraph failure reported in #111. The Eloquence Engine can finish at a phrase-final em dash without delivering the following Speech Index callback. The existing completion fallback reported only completion, which is not sufficient for NVDA's speech manager to advance.

## Verification

- `pytest`: 28 passed, 11 subtests passed
- `ruff check .`: passed
- live-tested with NVDA 2026.1.1 on Windows 10
- original rendered-Markdown Say-All stall is fixed
- single-character speech remains smooth after replacing a blocking synchronization prototype with the queued playback marker
