### PR TITLE
fix: fall back capital sharp s (ẞ) to lowercase ß

### DIFF
--- a/addon/synthDrivers/_text_preprocessing.py
+++ b/addon/synthDrivers/_text_preprocessing.py
@@ -195,6 +195,11 @@ def _resub(dct, s):
 # ---------------------------------------------------------------------------
 def preprocess(text, voice_id):
 	"""Apply crash prevention fixes and text normalization for *voice_id*."""
+	# Capital sharp s (ẞ, U+1E9E) is not in legacy Windows code pages and
+	# would be replaced with "?" by MBCS encoding.  Fall back to lowercase ß
+	# (U+00DF), which all Latin code pages recognise.  Applied globally
+	# because every Latin-based Eloquence voice can handle ß.
+	text = text.replace("\u1e9e", "\u00df")
 	# CHS and KOR get English fixes (they render embedded English text)
 	if voice_id in _ENGLISH_IDS + _CHINESE_ID + _KOREAN_ID:
 		text = _resub(english_fixes, text)

--- a/tests/test_text_preprocessing.py
+++ b/tests/test_text_preprocessing.py
@@ -21,6 +21,10 @@ class TextPreprocessingTests(unittest.TestCase):
 			with self.subTest(voice_id=voice_id):
 				self.assertEqual(preprocess("選設檢", voice_id), "選設檢")
 
+	def test_capital_sharp_s_falls_back_to_lowercase(self):
+		# ẞ (U+1E9E) should become ß (U+00DF), not "?"
+		self.assertEqual(preprocess("STRASSE \u1e9e", 65536), "STRASSE \u00df")
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary

Eloquence cannot process the capital sharp s character (ẞ, U+1E9E). It is not present in legacy Windows code pages, so MBCS encoding replaces it with '?'. The better behavior, as suggested in #128, is to fall back to the lowercase equivalent ß (U+00DF), which all Latin code pages recognise.

The replacement is applied globally (all voice IDs) because every Latin-based Eloquence voice can handle ß. Asian voices are unaffected — the replacement runs before the Asian-voice MBCS skip.

Capital pitch change is already handled correctly by NVDA, so only the character mapping needs fixing here.

Closes #128