### PR TITLE
Preserve caps pitch across language switches

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -442,6 +442,12 @@ PARAM_MAX = {
 	rgh: 100,
 	bth: 100,
 }
+# Temporary prosody changes (e.g. raised pitch for a capital letter) that are
+# currently in effect, as {param: (multiplier, offset)}.  set_voice() re-applies
+# these after a language change; without that, the base-param restore it does
+# would silently cancel a caps pitch raise queued just before the voice switch
+# (issue #130).
+_active_temp_prosody: Dict[int, Tuple[float, int]] = {}
 eciPath = os.path.abspath(os.path.join(os.path.dirname(__file__), "eloquence", "eci.dll"))
 langs = {
 	"esm": (131073, "Latin American Spanish"),
@@ -644,6 +650,10 @@ def cmdProsody(pr, multiplier, offset=0):
 	For revert: NVDA sends multiplier=1, offset=0.
 	Uses temporary=True so voice_params is never corrupted.
 	"""
+	if multiplier == 1 and offset == 0:
+		_active_temp_prosody.pop(pr, None)
+	else:
+		_active_temp_prosody[pr] = (multiplier, offset)
 	base = getVParam(pr)
 	value = int(base * multiplier + offset)
 	# Clamp to valid ECI parameter range.
@@ -659,6 +669,9 @@ def synth():
 
 
 def stop():
+	# NVDA re-sends any still-applicable prosody commands with the next
+	# utterance, so pending temporary prosody dies with the cancelled speech.
+	_active_temp_prosody.clear()
 	_client.stop()
 
 
@@ -703,6 +716,14 @@ def set_voice(vl):
 				)
 			except Exception:
 				pass
+		# Re-apply any temporary prosody still in effect (e.g. the raised pitch
+		# for a capital letter when the language change lands between the pitch
+		# raise and its revert).  The base-param restore above would otherwise
+		# cancel it and the capital would speak at normal pitch (issue #130).
+		for pr, (multiplier, offset) in _active_temp_prosody.items():
+			value = int(voice_params.get(pr, 0) * multiplier + offset)
+			value = max(0, min(value, PARAM_MAX.get(pr, 100)))
+			setVParam(pr, value, temporary=True)
 		# Update current language for proper encoding
 		_current_lang = VOICE_ID_TO_LANG.get(voice_id, "enu")
 		LOGGER.debug("Voice changed to ID %d, language code: %s", voice_id, _current_lang)

--- a/tests/test_temp_prosody.py
+++ b/tests/test_temp_prosody.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #130: temporary prosody must survive a voice switch.
+
+set_voice() restores the user's base voice params after eciSetParam(9); before
+the fix this silently cancelled a caps pitch raise applied just before the
+language change, so capitals in auto-switched languages spoke at normal pitch.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+
+def _install_nvda_stubs():
+	config = types.ModuleType("config")
+	config.conf = {"speech": {"eci": {}}, "audio": {"outputDevice": "default"}}
+	sys.modules["config"] = config
+
+	nvwave = types.ModuleType("nvwave")
+	nvwave.WavePlayer = type("WavePlayer", (), {"MIN_BUFFER_MS": 0})
+	sys.modules["nvwave"] = nvwave
+
+	build_version = types.ModuleType("buildVersion")
+	build_version.version_year = 2026
+	sys.modules["buildVersion"] = build_version
+
+
+def _import_real_eloquence():
+	_install_nvda_stubs()
+	# Load the real module under a private name so we never disturb the
+	# "addon.synthDrivers._eloquence" entry other test modules stub out
+	# (test_language_scope replaces it with a fake).
+	path = os.path.abspath(
+		os.path.join(os.path.dirname(__file__), "..", "addon", "synthDrivers", "_eloquence.py")
+	)
+	spec = importlib.util.spec_from_file_location("addon.synthDrivers._eloquence_real_i130", path)
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+_eloquence = _import_real_eloquence()
+
+
+class _FakeClient:
+	"""Records every command that would go to the Eloquence Host Process."""
+
+	def __init__(self):
+		self.commands = []
+		self._sequence = 0
+		self._player = None
+
+	def send_command(self, command, wait=True, **payload):
+		self.commands.append((command, payload))
+		return {"params": {}, "voiceParams": {}}
+
+	def stop(self):
+		self._sequence += 1
+
+
+BASE_PITCH = 65
+PITCH = _eloquence.pitch
+DEU = 262144
+
+
+class TempProsodyAcrossVoiceSwitchTests(unittest.TestCase):
+	def setUp(self):
+		self.client = _FakeClient()
+		_eloquence._client = self.client
+		_eloquence._active_temp_prosody.clear()
+		_eloquence.voice_params.clear()
+		_eloquence.voice_params.update(
+			{
+				_eloquence.rate: 50,
+				PITCH: BASE_PITCH,
+				_eloquence.vlm: 92,
+				_eloquence.fluctuation: 30,
+				_eloquence.hsz: 50,
+				_eloquence.rgh: 0,
+				_eloquence.bth: 0,
+			}
+		)
+
+	def _pitch_values_sent(self):
+		return [
+			(payload["value"], payload.get("temporary", False))
+			for command, payload in self.client.commands
+			if command == "setVoiceParam" and payload["paramId"] == PITCH
+		]
+
+	def test_caps_pitch_survives_language_change(self):
+		# The order a caps pitch raise and a language change can reach the
+		# synthesis worker in: PitchCommand(offset=30), then LangChangeCommand.
+		_eloquence.cmdProsody(PITCH, 1, 30)
+		_eloquence.set_voice(DEU)
+		values = self._pitch_values_sent()
+		self.assertEqual(
+			values[-1],
+			(BASE_PITCH + 30, True),
+			"temporary caps pitch must be re-applied after the language "
+			"change, not stomped by the base-param restore: %r" % values,
+		)
+
+	def test_no_reapply_after_prosody_reset(self):
+		_eloquence.cmdProsody(PITCH, 1, 30)
+		_eloquence.cmdProsody(PITCH, 1, 0)  # PitchCommand() revert
+		self.client.commands.clear()
+		_eloquence.set_voice(DEU)
+		values = self._pitch_values_sent()
+		self.assertEqual(
+			values[-1],
+			(BASE_PITCH, False),
+			"after a prosody revert the language change must leave pitch at "
+			"base: %r" % values,
+		)
+
+	def test_stop_clears_pending_prosody(self):
+		_eloquence.cmdProsody(PITCH, 1, 30)
+		_eloquence.stop()
+		self.client.commands.clear()
+		_eloquence.set_voice(DEU)
+		values = self._pitch_values_sent()
+		self.assertEqual(
+			values[-1],
+			(BASE_PITCH, False),
+			"cancelled speech must not leak its temporary pitch into the "
+			"next voice switch: %r" % values,
+		)
+
+	def test_reapplied_pitch_clamped_to_param_max(self):
+		_eloquence.voice_params[PITCH] = 90
+		_eloquence.cmdProsody(PITCH, 1, 30)
+		_eloquence.set_voice(DEU)
+		self.assertEqual(self._pitch_values_sent()[-1], (100, True))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Closes #130

## Problem

When automatic language switching selects a voice that doesn't match the default, the capital pitch change stops working: the language switch's parameter restore in `set_voice()` runs after the temporary caps pitch raise has been applied, and silently pushes the base pitch back to the engine before the capital is synthesized.

`set_voice()` restores the user's base voice params after `eciSetParam(9)` on purpose (that guard fixed the old "stuck pitch after language change" bug) — but it didn't account for a temporary prosody change still being in effect at that moment.

## Fix

`_eloquence.py` now tracks active temporary prosody (`cmdProsody` records it, a prosody revert or `stop()` clears it), and `set_voice()` re-applies it after its base-param restore. This makes caps pitch survive a voice switch regardless of the order in which the pitch and language-change commands reach the synthesis worker — the same order-robustness IBMTTS gets from its inline annotations.

## Verification

- New regression tests (`tests/test_temp_prosody.py`, 4 tests) at the host-command seam: red on the old code (capital pitch sent as `65` instead of `95`), green with the fix. Full suite: 29 passed.
- Measured end-to-end against the real ECI engine (driver + host process + `ECI.DLL`), estimating F0 of the synthesized audio: the failing command order now produces the raised pitch (344.5 Hz) instead of base (119.8 Hz); all previously-working orderings, including rapid cancel stress, are unchanged.

Note for testers: this is a Synth-Driver-side change only — no host exe rebuild needed. Reports of the same symptom on specific NVDA builds/configurations are still welcome on #130 to confirm this covers every path reporters hit.