### PR TITLE
Fix speech index playback ordering

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -48,6 +48,7 @@ class AudioWorker(threading.Thread):
 		self._player_lock = threading.RLock()
 
 	def run(self) -> None:
+		pending_audio: Optional[AudioChunk] = None
 		while self._running:
 			try:
 				chunk = self._queue.get(timeout=0.1)
@@ -56,47 +57,78 @@ class AudioWorker(threading.Thread):
 			if chunk is None:
 				break
 			data, index, is_final, seq = chunk
+			if pending_audio and pending_audio[3] < self._client._sequence:
+				pending_audio = None
 			if seq < self._client._sequence:
 				self._queue.task_done()
 				continue
 
-			# --- New logic (EARCONS patch) ---
-			if not data:
-				if not self._stopping:
-					if index is not None:
-						self._invoke_index_callback(index)
-					if is_final:
-						self._schedule_idle()
-				self._queue.task_done()
-				continue
-			# ------------------------------------
-
-			on_done = None
-			if index is not None:
-
-				def _callback(i=index):
-					self._invoke_index_callback(i)
-
-				on_done = _callback
-
-			wrapped_on_done = self._make_on_done(on_done, is_final)
-
-			# Early exit if stopping - avoids unnecessary lock acquisition
-			if self._stopping:
+			if data:
+				# Hold one real Audio Chunk so a following index-only event can use
+				# WavePlayer's completion callback without feeding a synthetic sample.
+				if pending_audio:
+					self._feed_audio(*pending_audio[:3])
+				pending_audio = chunk
 				self._queue.task_done()
 				continue
 
-			# Feed directly - blocks if buffer is full
-			try:
-				with self._player_lock:
-					if not self._stopping:
-						if self._player:
-							self._player.feed(data, onDone=wrapped_on_done)
-			except FileNotFoundError:
-				LOGGER.warning("Sound device not found during feed")
-			except Exception:
-				LOGGER.exception("WavePlayer feed failed")
+			# The Eloquence Host Process reports Speech Indexes as index-only
+			# events. Attach the notification to the preceding real Audio Chunk so
+			# NVDA receives it only after that audio finishes playing.
+			if pending_audio:
+				pending_data, pending_index, pending_final, _pending_seq = pending_audio
+				self._feed_audio(
+					pending_data,
+					index if index is not None else pending_index,
+					pending_final,
+				)
+				pending_audio = None
+				index = None
+			if not self._stopping:
+				if index is not None:
+					self._sync_and_invoke_index(index)
+				if is_final:
+					self._schedule_idle()
 			self._queue.task_done()
+
+	def _feed_audio(self, data: bytes, index: Optional[int], is_final: bool) -> None:
+		"""Feed a real Audio Chunk and attach its Speech Progress Notification."""
+
+		on_done = None
+		if index is not None:
+
+			def _callback(i=index):
+				self._invoke_index_callback(i)
+
+			on_done = _callback
+
+		wrapped_on_done = self._make_on_done(on_done, is_final) if on_done or is_final else None
+
+		# Early exit if stopping - avoids unnecessary lock acquisition
+		if self._stopping:
+			return
+
+		# Feed directly - blocks if buffer is full
+		try:
+			with self._player_lock:
+				if not self._stopping:
+					if self._player:
+						self._player.feed(data, onDone=wrapped_on_done)
+		except FileNotFoundError:
+			LOGGER.warning("Sound device not found during feed")
+		except Exception:
+			LOGGER.exception("WavePlayer feed failed")
+
+	def _sync_and_invoke_index(self, index: int) -> None:
+		"""Report a Speech Index that has no real Audio Chunk to carry it."""
+		try:
+			with self._player_lock:
+				if not self._stopping and self._player:
+					self._player.sync()
+		except Exception:
+			LOGGER.exception("WavePlayer sync failed")
+		if not self._stopping:
+			self._invoke_index_callback(index)
 
 	def stop(self) -> None:
 		self._stopping = True

--- a/tests/test_audio_worker.py
+++ b/tests/test_audio_worker.py
@@ -41,9 +41,21 @@ def _load_client_module():
 class FakePlayer:
 	def __init__(self, events):
 		self.events = events
+		self.on_done = []
 
 	def feed(self, data, onDone=None):
 		self.events.append(("feed", data))
+		if onDone:
+			self.on_done.append(onDone)
+
+	def sync(self):
+		self.events.append(("sync", None))
+		while self.on_done:
+			self.on_done.pop(0)()
+
+	def idle(self):
+		self.events.append(("idle", None))
+		self.sync()
 
 
 class FakeClient:
@@ -51,9 +63,10 @@ class FakeClient:
 
 
 class AudioWorkerTests(unittest.TestCase):
-	def test_empty_index_chunk_fires_callback_without_feeding_player(self):
-		# Index-only chunks must never reach WavePlayer.feed: degenerate
-		# tiny buffers can cause audible clicks on some devices (see #127).
+	def test_index_notification_waits_for_preceding_audio(self):
+		# Index-only chunks must never reach WavePlayer.feed: degenerate tiny
+		# buffers can cause audible clicks on some devices (see #127). Attach the
+		# Speech Progress Notification to the preceding real Audio Chunk instead.
 		module = _load_client_module()
 		events = []
 		module.onIndexReached = lambda index: events.append(("index", index))
@@ -66,7 +79,46 @@ class AudioWorkerTests(unittest.TestCase):
 
 		worker.run()
 
+		self.assertEqual(events, [("feed", b"audio")])
+		self.assertEqual(len(player.on_done), 1)
+
+		player.on_done[0]()
+
 		self.assertEqual(events, [("feed", b"audio"), ("index", 42)])
+
+	def test_index_notification_is_attached_to_last_preceding_audio_chunk(self):
+		module = _load_client_module()
+		events = []
+		module.onIndexReached = lambda index: events.append(("index", index))
+		audio_queue = queue.Queue()
+		audio_queue.put((b"first", None, False, 0))
+		audio_queue.put((b"last", None, False, 0))
+		audio_queue.put((b"", 42, False, 0))
+		audio_queue.put(None)
+		player = FakePlayer(events)
+
+		module.AudioWorker(player, audio_queue, FakeClient()).run()
+
+		self.assertEqual(events, [("feed", b"first"), ("feed", b"last")])
+		self.assertEqual(len(player.on_done), 1)
+		player.on_done[0]()
+		self.assertEqual(events[-1], ("index", 42))
+
+	def test_completion_follows_preceding_index_and_audio(self):
+		module = _load_client_module()
+		events = []
+		module.onIndexReached = lambda index: events.append(("index", index))
+		audio_queue = queue.Queue()
+		audio_queue.put((b"audio", None, False, 0))
+		audio_queue.put((b"", 42, False, 0))
+		audio_queue.put((b"", None, True, 0))
+		audio_queue.put(None)
+		player = FakePlayer(events)
+
+		module.AudioWorker(player, audio_queue, FakeClient()).run()
+
+		self.assertLess(events.index(("feed", b"audio")), events.index(("index", 42)))
+		self.assertLess(events.index(("index", 42)), events.index(("index", None)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- preserve NVDA Speech Index playback ordering by attaching index notifications to the preceding real audio chunk
- avoid the synthetic one-sample WavePlayer marker that caused clicks on short speech
- wait for playback before reporting indexes that have no pending audio chunk

## Verification

- `cmd /c runpytest.bat` — 35 passed
- `cmd /c runlint.bat` — passed
- `cmd /c scons.bat` — built `Eloquence-v18-15-gd883500.nvda-addon`
- two-axis review — no Standards blockers and no Spec findings