### PR TITLE
Stop collapsing NVDA's chunk separator before full month names

### DIFF
--- a/addon/synthDrivers/_text_preprocessing.py
+++ b/addon/synthDrivers/_text_preprocessing.py
@@ -24,23 +24,26 @@ _PHRASE_FINAL_EM_DASH = re.compile(r"\u2014(?=[\"'\u2019\u201d)\]}]*\s*$)")
 # Crash prevention dictionaries
 # ---------------------------------------------------------------------------
 # Each dictionary maps a compiled regex to a replacement string.  _resub()
-# applies them in insertion order, which matters for the date parser pair.
+# applies them in insertion order.
 
 english_fixes = {
 	re.compile(r"(\w+)\.([a-zA-Z]+)"): r"\1 dot \2",
 	re.compile(r"([a-zA-Z0-9_]+)@(\w+)"): r"\1 at \2",
 	# Mc prefix split crash (covers McName and McDONALD)
 	re.compile(r"\b(Mc)\s+([A-Z][a-z]|[A-Z][A-Z]+)"): r"\1\2",
-	# Date parser bug: "03 Marble" misread as "march ble" (abbreviated first)
+	# Date parser bug: "03 Marble" misread as "march ble".  The second space
+	# stops the engine's date parser fusing the number with the month-prefixed
+	# word.  Genuine full month names are excluded via lookahead so real dates
+	# ("14 March") still read as dates.  No pattern may ever *collapse* a
+	# double space: NVDA separates speech chunks (e.g. a "row 14" table
+	# announcement and a "March" cell) with two spaces, and removing that
+	# separator makes the engine read the chunks as one date.
 	re.compile(
-		r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)"
+		r"\b(\d+) (?!(?:January|February|March|April|May|June|July|August"
+		r"|September|October|November|December)\b)"
+		r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)"
 		r"([a-z]+)"
 	): r"\1  \2\3",
-	# Undo double-space for actual full month names
-	re.compile(
-		r"\b(\d+)  (January|February|March|April|May|June|July|August"
-		r"|September|October|November|December)\b"
-	): r"\1 \2",
 	# caesure / cæsure crash
 	re.compile(r"c(ae|\xe6)sur(e)?", re.I): r"seizur",
 	# h' + r/v + e crash

--- a/tests/test_text_preprocessing.py
+++ b/tests/test_text_preprocessing.py
@@ -28,6 +28,45 @@ class TextPreprocessingTests(unittest.TestCase):
 		# ẞ (U+1E9E) should become ß (U+00DF), not "?"
 		self.assertEqual(preprocess("STRASSE \u1e9e", 65536), "STRASSE \u00df")
 
+	def test_month_prefix_words_are_split_from_preceding_numbers(self):
+		# ECI date parser bug: "03 Marble" would read as "March thirdble".
+		# The extra space stops the engine fusing the number and the word.
+		self.assertEqual(preprocess("03 Marble", 65536), "03  Marble")
+
+	def test_genuine_dates_keep_their_single_space(self):
+		# A real date inside one speech chunk should still reach the engine
+		# untouched so it reads as a date.
+		self.assertEqual(
+			preprocess("I arrived on 14 March 2020", 65536),
+			"I arrived on 14 March 2020",
+		)
+
+	def test_nvda_chunk_separator_before_month_is_preserved(self):
+		# NVDA joins separate speech chunks (e.g. the "row 14" announcement
+		# and a "March" table cell) with CHUNK_SEPARATOR, two spaces.  The
+		# double space stops the ECI date parser fusing the chunks; removing
+		# it makes "row 14  March" read as "row March 14".  Preprocessing
+		# must never collapse it.
+		for month in (
+			"January",
+			"February",
+			"March",
+			"April",
+			"May",
+			"June",
+			"July",
+			"August",
+			"September",
+			"October",
+			"November",
+			"December",
+		):
+			with self.subTest(month=month):
+				self.assertEqual(
+					preprocess(f"row 14  {month}  ", 65536),
+					f"row 14  {month}  ",
+				)
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Symptom

Table navigation with a month-name cell misreads the row announcement as a date: moving onto a row whose cell is "March" speaks **"Row March 14"** instead of "row 14 March". This is the table-specific incarnation of the old "3 Marble" -> "March thirdble" date-parser bug.

## Root cause

1. NVDA appends `CHUNK_SEPARATOR` (two spaces) to every string item in a Speech Sequence, so the row announcement and the cell content reach the Synth Driver as `"row 14  "` + `"March  "`, joined to `"row 14  March"`.
2. That double space is exactly what stops the Eloquence Engine''s date parser from fusing the two chunks (verified against the real engine).
3. The `english_fixes` pattern pair inserts a double space to defuse "3 Marble", then a second pattern ("undo double-space for actual full month names") collapses `digit + two spaces + full month` back to a single space. It cannot distinguish its own insertions from NVDA''s chunk separator, so it rewrites `"row 14  March"` to `"row 14 March"` and the engine date-parses it.

This is why only full month names trip it (only they are in the undo list) and why it shows up in tables (number announcement chunk directly followed by a month chunk).

## Fix

Exclude full month names from the "3 Marble" defusing pattern via negative lookahead and delete the undo pattern entirely, so Text Preprocessing never removes a double space. Behavior otherwise unchanged:

- "03 Marble" still becomes "03  Marble" (crash/date defusing kept)
- genuine in-chunk dates ("I arrived on 14 March 2020") still read as dates

Synth Driver side only; no Eloquence Host Process rebuild needed.

## Verification

- End-to-end harness (real driver + host exe + ECI.DLL, fake NVDA, PCM captured in-process): the NVDA-shaped sequence `["row 14  ", "March  "]` rendered PCM matching the ear-confirmed fused "row March 14" before the fix, and the unfused "row fourteen March" after. Genuine one-string "row 14 March" still reads as a date.
- Ruled out along the way: adjacent-string concatenation (unspaced "14March" does not date-parse) and cross-addText fusion (per-item backquote prefixes already break the parse).
- Regression tests added in `tests/test_text_preprocessing.py`: chunk separator preserved before all 12 month names, Marble defusing intact, genuine dates intact. Full suite: 38 passed.