### PR TITLE
Shut the 32-bit host down cleanly on synth terminate

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -25,6 +25,9 @@ LOGGER = logging.getLogger(__name__)
 HOST_EXECUTABLE = "eloquence_host32.exe"
 HOST_SCRIPT = "host_eloquence32.py"
 AUTH_KEY_BYTES = 16
+# Seconds to let the host exit on its own before we terminate it. A onefile
+# PyInstaller build only removes its _MEI temp directory on a clean exit.
+HOST_EXIT_TIMEOUT = 3.0
 
 
 # Audio handling -----------------------------------------------------------------
@@ -421,11 +424,25 @@ class EloquenceHostClient:
 			self.send_command("delete")
 		except Exception:
 			LOGGER.exception("Failed to delete host cleanly")
+		# Let the host exit on its own before touching the socket. Closing the
+		# connection first resets it underneath the host, which turns every
+		# in-flight send into a ConnectionResetError; those escape the host's
+		# serve loop as an unhandled exception and, in a --noconsole build,
+		# surface as an error dialog.
+		exited = False
+		try:
+			self._host.process.wait(timeout=HOST_EXIT_TIMEOUT)
+			exited = True
+		except Exception:
+			LOGGER.warning(
+				"Eloquence host did not exit within %ss; terminating",
+				HOST_EXIT_TIMEOUT,
+			)
 		# Wait for receiver thread to finish (it will get EOFError and exit)
 		if self._receiver:
 			self._receiver.join(timeout=2)
 			self._receiver = None
-		# Now close connections and terminate process
+		# Now close connections, and terminate the process only if it is still up.
 		try:
 			self._host.connection.close()
 		except Exception:
@@ -434,15 +451,19 @@ class EloquenceHostClient:
 			self._host.listener.close()
 		except Exception:
 			pass
-		try:
-			self._host.process.terminate()
-			self._host.process.wait(timeout=2)
-		except Exception:
-			LOGGER.exception("Failed to terminate host process")
+		if not exited:
+			# terminate() is TerminateProcess on Windows and cannot be blocked, so
+			# the bootloader never gets to clean up its _MEI directory. Only
+			# reached when the graceful wait above timed out.
 			try:
-				self._host.process.kill()
+				self._host.process.terminate()
+				self._host.process.wait(timeout=2)
 			except Exception:
-				pass
+				LOGGER.exception("Failed to terminate host process")
+				try:
+					self._host.process.kill()
+				except Exception:
+					pass
 		self._host = None
 
 

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -797,6 +797,15 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
 	def terminate(self):
 		_eloquence.close_audio()
+		# Shut the 32-bit host process down. Without this the host is never asked
+		# to exit, so its onefile bootloader never removes the _MEI directory it
+		# extracted, and its in-flight sends die on a reset socket rather than a
+		# closed one. Wrapped so a shutdown failure cannot block switching away
+		# from this synth.
+		try:
+			_eloquence.terminate()
+		except Exception:
+			log.exception("Eloquence host shutdown failed")
 		# Safe settings panel removal - won't crash if it was never registered
 		try:
 			if hasattr(gui.settingsDialogs, "NVDASettingsDialog"):


### PR DESCRIPTION
Addresses the root cause in #141.

`_eloquence.terminate()` was never called. `SynthDriver.terminate()` called `close_audio()` and then went straight to the settings panel cleanup, so `EloquenceHostClient.shutdown()` and the whole `delete` handshake with the host were dead code. The host was abandoned rather than asked to exit.

Two changes:

1. `SynthDriver.terminate()` now calls `_eloquence.terminate()`, wrapped in try/except so a shutdown failure cannot block switching away from the synth. `initialize()` already calls `_ensure_synth_worker()` and `ensure_started()` respawns the host, so switching away and back still works.

2. `shutdown()` now waits up to `HOST_EXIT_TIMEOUT` (3 seconds) for the process to exit before closing the socket, and only falls back to `terminate()` if that wait times out. It previously closed the connection and then called `terminate()` unconditionally, which on Windows is `TerminateProcess` and cannot be blocked, so the onefile bootloader never got to remove its `_MEI` directory even when it would have.

## Testing

- `pytest`: 38 passed, 23 subtests passed. `ruff check` and `ruff format --check` clean on both files.
- Running against v20 on NVDA 2026.2rc2, Windows 11 25H2, since 2026-08-30. Across NVDA restarts, `%TEMP%` holds exactly one `_MEI` directory belonging to the live host, the previous host's directory is removed each time, NVDA logs "application eloquence_host32 closed", no error dialog appears, and `eloquence-host.log` stays at zero bytes. Before the change I was accumulating one `_MEI` directory per restart, 19 of them in a day.

The unit suite does not cover the shutdown path and I have not added a test for it, since exercising it needs a live host process. Happy to add one if you would like a fake-host harness for it.

Not included here: the two host-side fixes described in #141, the unguarded `send` in `serve_forever`'s `except` branch and the unbounded `_send_event` logging. Those are in `host_eloquence32.py` and I do not have a 32-bit build environment to test a rebuild.

## Disclosure

I used Claude Code to help trace this and to check my reading of the code. The change is tested on my own machine as described above.
