### PR TITLE
Fix host-side shutdown issues and clean up log file

### DIFF
--- a/host_eloquence32.py
+++ b/host_eloquence32.py
@@ -156,12 +156,17 @@ def get_dictionary_candidates(language_code: str) -> tuple[tuple[str, ...], tupl
 
 
 def configure_logging(log_dir: Optional[str]) -> None:
-	"""Initialise logging for the helper."""
+	"""Initialise logging for the helper.
+
+	The log file is truncated at startup so each host invocation starts fresh
+	and old error output does not accumulate across NVDA restarts.  On a clean
+	exit with no errors the file stays at zero bytes.
+	"""
 	log_file = None
 	if log_dir:
 		log_file = os.path.join(log_dir, "eloquence-host.log")
 		try:
-			with open(log_file, "a"):
+			with open(log_file, "w"):
 				pass
 		except OSError:
 			log_file = None
@@ -206,15 +211,20 @@ class EloquenceRuntime:
 		self._speaking = False
 		self._saw_final_index = False
 		self._pending_indexes: list[int] = []
+		self._send_disabled = False
 
 	# ------------------------------------------------------------------
 	# Communication helpers
 	def _send_event(self, event: str, **payload: object) -> None:
+		if self._send_disabled:
+			return
 		# LOGGER.debug("Sending event %s", event)
 		try:
 			self._conn.send({"type": "event", "event": event, "payload": payload})
 		except Exception:
-			LOGGER.exception("Failed to send event %s", event)
+			if not self._send_disabled:
+				self._send_disabled = True
+				LOGGER.error("Failed to send event %s; further sends disabled", event)
 
 	def _send_response(self, msg_id: int, **payload: object) -> None:
 		# LOGGER.debug("Sending response for %s", msg_id)
@@ -295,7 +305,9 @@ class EloquenceRuntime:
 					path = os.path.join(dictionary_dir, candidate)
 					if os.path.exists(path):
 						# LOGGER.debug("Loading dictionary index=%s file=%s", index, path)
-						self._dll.eciLoadDict(self._handle, self._dictionary_handle, index, path.encode("mbcs"))
+						self._dll.eciLoadDict(
+							self._handle, self._dictionary_handle, index, path.encode("mbcs")
+						)
 						break
 			self._loaded_dictionary_languages.add(language_code)
 		self._dll.eciSetDict(self._handle, self._dictionary_handle)
@@ -481,7 +493,10 @@ class HostController:
 			handler = self._handlers.get(command)
 			if handler is None:
 				LOGGER.error("Unknown command %s", command)
-				self._conn.send({"type": "response", "id": msg_id, "error": "unknownCommand"})
+				try:
+					self._conn.send({"type": "response", "id": msg_id, "error": "unknownCommand"})
+				except Exception:
+					LOGGER.error("Failed to send error response for unknown command %s", command)
 				continue
 			try:
 				payload = handler(**message.get("payload", {}))
@@ -491,7 +506,10 @@ class HostController:
 					break
 			except Exception as exc:
 				LOGGER.exception("Command %s failed", command)
-				self._conn.send({"type": "response", "id": msg_id, "error": str(exc)})
+				try:
+					self._conn.send({"type": "response", "id": msg_id, "error": str(exc)})
+				except Exception:
+					LOGGER.error("Failed to send error response for command %s", command)
 
 	# ------------------------------------------------------------------
 	# Command handlers

--- a/tests/test_host_shutdown.py
+++ b/tests/test_host_shutdown.py
@@ -1,0 +1,181 @@
+"""Tests for the host-side shutdown and logging fixes (#141)."""
+
+import ctypes
+import logging
+import os
+import tempfile
+import unittest
+
+# host_eloquence32.py uses ctypes.WINFUNCTYPE at module load time, which only
+# exists on Windows.  Provide a stub so the module imports on non-Windows CI.
+if not hasattr(ctypes, "WINFUNCTYPE"):
+	ctypes.WINFUNCTYPE = ctypes.CFUNCTYPE  # type: ignore[attr-defined]
+
+import host_eloquence32 as host
+
+
+class FailingConnection:
+	"""A connection whose send() always raises, simulating a broken socket."""
+
+	def __init__(self):
+		self.send_count = 0
+
+	def send(self, message):
+		self.send_count += 1
+		raise ConnectionResetError("simulated broken pipe")
+
+
+class RecordingConnection:
+	"""A connection that records all sent messages."""
+
+	def __init__(self):
+		self.messages = []
+
+	def send(self, message):
+		self.messages.append(message)
+
+
+class FakeDll:
+	def __init__(self):
+		self.calls = []
+
+	def eciNewDict(self, handle):
+		return 1
+
+	def eciSetDict(self, handle, dictionary_handle):
+		pass
+
+	def eciLoadDict(self, handle, dictionary_handle, index, path):
+		pass
+
+	def eciSetParam(self, handle, param_id, value):
+		pass
+
+	def eciGetVoiceParam(self, handle, voice, param_id):
+		return param_id
+
+
+def make_runtime(conn=None):
+	runtime = host.EloquenceRuntime(
+		conn=conn or RecordingConnection(),  # type: ignore[arg-type]
+		config=host.HostConfig(
+			eci_path="",
+			data_directory="",
+			language_code="enu",
+			enable_abbrev_dict=False,
+			enable_phrase_prediction=False,
+			voice_variant=0,
+		),
+	)
+	runtime._dll = FakeDll()  # type: ignore[assignment]
+	runtime._handle = "eci"
+	return runtime
+
+
+class SendEventDisableTests(unittest.TestCase):
+	"""_send_event must stop attempting sends after the first failure."""
+
+	def test_send_disabled_after_first_failure(self):
+		conn = FailingConnection()
+		runtime = make_runtime(conn)  # type: ignore[arg-type]
+		# First call tries to send and fails
+		runtime._send_event("audio", data=b"x", index=None, final=False)
+		self.assertTrue(runtime._send_disabled)
+		# First failed send actually called conn.send once
+		self.assertEqual(conn.send_count, 1)
+		# Subsequent calls must not even try
+		runtime._send_event("audio", data=b"y", index=None, final=False)
+		runtime._send_event("stopped")
+		self.assertEqual(conn.send_count, 1)
+
+	def test_send_not_disabled_when_connection_works(self):
+		conn = RecordingConnection()
+		runtime = make_runtime(conn)  # type: ignore[arg-type]
+		runtime._send_event("audio", data=b"x", index=None, final=False)
+		self.assertFalse(runtime._send_disabled)
+		self.assertEqual(len(conn.messages), 1)
+
+
+class ServeForeverErrorSendGuardTests(unittest.TestCase):
+	"""serve_forever must not crash when the error-response send fails."""
+
+	def test_error_response_send_failure_does_not_crash(self):
+		class FailingRecvConnection:
+			def __init__(self):
+				self._messages = [
+					{"type": "command", "id": 1, "command": "bogus", "payload": {}},
+				]
+
+			def recv(self):
+				if not self._messages:
+					raise EOFError
+				return self._messages.pop(0)
+
+			def send(self, message):
+				# The error-response send must fail
+				if message.get("id") == 1 and "error" in message:
+					raise ConnectionResetError("simulated")
+				pass
+
+		conn = FailingRecvConnection()
+		controller = host.HostController(conn)  # type: ignore[arg-type]
+		# This must not raise — the error-response send failure is caught
+		controller.serve_forever()
+		# Reached here = no unhandled exception
+		self.assertTrue(True)
+
+	def test_unknown_command_error_response_still_sent(self):
+		"""When the connection is healthy, the error response IS delivered."""
+
+		class HealthyConnection:
+			def __init__(self):
+				self.sent = []
+
+			def recv(self):
+				if not self.sent:
+					return {"type": "command", "id": 1, "command": "bogus", "payload": {}}
+				raise EOFError
+
+			def send(self, message):
+				self.sent.append(message)
+
+		conn = HealthyConnection()
+		controller = host.HostController(conn)  # type: ignore[arg-type]
+		controller.serve_forever()
+		error_responses = [m for m in conn.sent if "error" in m]
+		self.assertEqual(len(error_responses), 1)
+		self.assertEqual(error_responses[0]["error"], "unknownCommand")
+
+
+class ConfigureLoggingTruncationTests(unittest.TestCase):
+	"""configure_logging must truncate (not append to) the log file."""
+
+	def setUp(self):
+		# Save and clear existing handlers so tests don't interfere with each
+		# other or leak handlers into the global logger.
+		self._saved_handlers = logging.getLogger().handlers.copy()
+		logging.getLogger().handlers.clear()
+
+	def tearDown(self):
+		logging.getLogger().handlers = self._saved_handlers
+
+	def test_log_file_truncated_on_startup(self):
+		with tempfile.TemporaryDirectory() as log_dir:
+			log_path = os.path.join(log_dir, "eloquence-host.log")
+			# Pre-write some stale content
+			with open(log_path, "w") as f:
+				f.write("stale error log from previous session\n" * 100)
+			self.assertGreater(os.path.getsize(log_path), 0)
+
+			# Reconfigure — should truncate
+			host.configure_logging(log_dir)
+			# The file should now be empty (no errors logged yet at level ERROR)
+			self.assertEqual(os.path.getsize(log_path), 0)
+
+	def test_log_file_without_dir(self):
+		# Must not crash when log_dir is None
+		host.configure_logging(None)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Problem

Addresses the two host-side fixes described in #141 that were explicitly excluded from PR #142, plus log file cleanup.

## Changes

### 1. Guard unguarded sends in serve_forever (host_eloquence32.py)

Two call sites in `HostController.serve_forever` sent response messages without exception handling:

- The `unknownCommand` error response — sent directly when a handler is not found
- The exception-handler error response — sent in the `except` block when a command handler raises

If the connection was already broken (e.g. the controller closed the socket during shutdown), these sends raised `ConnectionResetError` / `BrokenPipeError` and crashed the serve loop with an unhandled exception. In a `--noconsole` PyInstaller build, this surfaces as a Windows error dialog.

Both sends are now wrapped in `try/except` that logs the secondary failure without re-raising.

### 2. Bound unbounded _send_event logging (host_eloquence32.py)

`_send_event` caught send failures and called `LOGGER.exception()`, which logs a full traceback at ERROR level. When the connection broke during synthesis, audio callbacks fired repeatedly — each calling `_send_event`, each logging a full traceback. The log file grew without bound.

Now, after the first send failure, `_send_disabled` is set to `True` and all subsequent `_send_event` calls return immediately without attempting the send or logging. The initial failure is logged once at ERROR level. This also prevents the host from burning CPU on repeated `sendall` syscalls into a dead socket.

### 3. Truncate log file at startup (host_eloquence32.py)

`configure_logging` opened the log file in append mode (`"a"`), so error output from every previous host invocation accumulated across NVDA restarts. Now it opens in truncate mode (`"w"`), so each host session starts with a clean log file. On a clean exit with no errors, the file stays at zero bytes — matching the behaviour described in PR #142's testing notes.

## Testing

- **New unit tests**: `tests/test_host_shutdown.py` — 6 tests covering all three fixes:
  - `SendEventDisableTests`: verifies `_send_event` disables after first failure and stops attempting sends
  - `ServeForeverErrorSendGuardTests`: verifies serve_forever doesn't crash when error-response sends fail, and still delivers error responses when the connection is healthy
  - `ConfigureLoggingTruncationTests`: verifies the log file is truncated at startup
- `pytest tests/test_host_shutdown.py` — 6 passed
- `pytest tests/test_host_shutdown.py tests/test_audio_worker.py` — 9 passed (no regressions)
- `ruff check` and `ruff format --check` clean on both modified files

## Not included

No changes to the client-side (`_eloquence.py` / `eloquence.py`) — those were handled in PR #142. This PR only touches the 32-bit host process.