### PR TITLE
Kill an orphaned Eloquence Host Process with a Job Object

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 from . import _eloquence_ipc as _ipc
+from . import _eloquence_job as _job
 
 import config
 import nvwave
@@ -186,6 +187,8 @@ class HostProcess:
 class EloquenceHostClient:
 	def __init__(self) -> None:
 		self._host: Optional[HostProcess] = None
+		# Outlives every Eloquence Host Process we spawn; closed only when NVDA exits.
+		self._job: Optional[_job.HostJob] = None
 		self._pending: Dict[int, threading.Event] = {}
 		self._responses: Dict[int, Dict[str, Any]] = {}
 		self._receiver: Optional[threading.Thread] = None
@@ -221,6 +224,7 @@ class EloquenceHostClient:
 		)
 		LOGGER.info("Launching Eloquence host: %s", cmd)
 		proc = subprocess.Popen(cmd, cwd=addon_dir)
+		self._adopt_into_job(proc)
 		try:
 			conn = _ipc.accept_authenticated(listener, authkey)
 		except (TimeoutError, OSError) as exc:
@@ -244,6 +248,28 @@ class EloquenceHostClient:
 		self._host = HostProcess(process=proc, connection=conn, listener=listener)
 		self._receiver = threading.Thread(target=self._receiver_loop, daemon=True)
 		self._receiver.start()
+
+	def _adopt_into_job(self, proc: subprocess.Popen) -> None:
+		"""Put a freshly spawned Eloquence Host Process into the kill-on-close Job Object.
+
+		Called before the Host Channel is accepted so that an Eloquence Host Process
+		that never connects is covered too.  Purely a backstop: shutdown() still drives the
+		cooperative exit, and the job only decides what happens when NVDA dies
+		without getting to run it.
+		"""
+		if self._job is None:
+			self._job = _job.HostJob.create()
+		if self._job is None:
+			return
+		try:
+			handle = int(proc._handle)
+		except Exception:
+			LOGGER.warning(
+				"Eloquence Host Process exposes no handle; skipping Job Object",
+				exc_info=True,
+			)
+			return
+		self._job.assign(handle)
 
 	def _resolve_host_executable(self, addon_dir: str) -> Sequence[str]:
 		override = os.environ.get("ELOQUENCE_HOST_COMMAND")

--- a/addon/synthDrivers/_eloquence_job.py
+++ b/addon/synthDrivers/_eloquence_job.py
@@ -1,0 +1,164 @@
+"""Windows Job Object backstop that kills the Eloquence Host Process with NVDA.
+
+The Synth Driver side asks the Eloquence Host Process to exit over the Host
+Channel on ``terminate()``, and that cooperative path is the one that matters:
+a onefile PyInstaller build only removes its ``_MEI`` temp directory when it
+exits on its own.
+
+The handshake cannot run when NVDA never gets the chance to send it.  A crash,
+a ``taskkill /f``, or an Eloquence Engine call that never returns all leave the
+Eloquence Host Process orphaned, holding an Eloquence Engine handle and often
+the output device, until someone notices it in Task Manager.
+
+A Job Object created with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` closes that gap
+without the Eloquence Host Process cooperating.  The Synth Driver side holds the
+only handle to the job, so when the NVDA process goes away for any reason the
+kernel closes that handle and terminates every process still in the job.
+
+This is strictly a backstop.  It is never used to shut the Eloquence Host Process
+down normally, because a job kill is ``TerminateProcess`` and leaves the ``_MEI``
+directory behind - exactly what the cooperative path exists to avoid.  Every
+failure here is logged and ignored: a missing backstop must never stop Eloquence
+speaking.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import threading
+from ctypes import wintypes
+from typing import Optional
+
+LOGGER = logging.getLogger(__name__)
+
+# winnt.h
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+# JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation
+_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+
+# ULONG_PTR and SIZE_T are pointer sized; c_size_t is correct for both bitnesses.
+_ULONG_PTR = ctypes.c_size_t
+
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+	_fields_ = [
+		("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+		("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+		("LimitFlags", wintypes.DWORD),
+		("MinimumWorkingSetSize", _ULONG_PTR),
+		("MaximumWorkingSetSize", _ULONG_PTR),
+		("ActiveProcessLimit", wintypes.DWORD),
+		("Affinity", _ULONG_PTR),
+		("PriorityClass", wintypes.DWORD),
+		("SchedulingClass", wintypes.DWORD),
+	]
+
+
+class _IO_COUNTERS(ctypes.Structure):
+	_fields_ = [
+		("ReadOperationCount", ctypes.c_ulonglong),
+		("WriteOperationCount", ctypes.c_ulonglong),
+		("OtherOperationCount", ctypes.c_ulonglong),
+		("ReadTransferCount", ctypes.c_ulonglong),
+		("WriteTransferCount", ctypes.c_ulonglong),
+		("OtherTransferCount", ctypes.c_ulonglong),
+	]
+
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+	_fields_ = [
+		("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+		("IoInfo", _IO_COUNTERS),
+		("ProcessMemoryLimit", _ULONG_PTR),
+		("JobMemoryLimit", _ULONG_PTR),
+		("PeakProcessMemoryUsed", _ULONG_PTR),
+		("PeakJobMemoryUsed", _ULONG_PTR),
+	]
+
+
+def _kernel32() -> ctypes.WinDLL:
+	kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+	kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+	kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+	kernel32.SetInformationJobObject.argtypes = [
+		wintypes.HANDLE,
+		ctypes.c_int,
+		wintypes.LPVOID,
+		wintypes.DWORD,
+	]
+	kernel32.SetInformationJobObject.restype = wintypes.BOOL
+	kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+	kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+	kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+	kernel32.CloseHandle.restype = wintypes.BOOL
+	return kernel32
+
+
+class HostJob:
+	"""A kill-on-close Job Object holding the spawned Eloquence Host Processes."""
+
+	def __init__(self, handle: int, kernel32: ctypes.WinDLL):
+		self._handle: Optional[int] = handle
+		self._kernel32 = kernel32
+		self._lock = threading.Lock()
+
+	@classmethod
+	def create(cls) -> Optional["HostJob"]:
+		"""Return a kill-on-close HostJob, or None if Windows refused to make one."""
+		try:
+			kernel32 = _kernel32()
+			handle = kernel32.CreateJobObjectW(None, None)
+			if not handle:
+				raise ctypes.WinError(ctypes.get_last_error())
+			info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+			info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+			ok = kernel32.SetInformationJobObject(
+				handle,
+				_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+				ctypes.byref(info),
+				ctypes.sizeof(info),
+			)
+			if not ok:
+				error = ctypes.WinError(ctypes.get_last_error())
+				kernel32.CloseHandle(handle)
+				raise error
+		except Exception:
+			LOGGER.warning(
+				"Could not create the Job Object; an orphaned Eloquence Host Process"
+				" will outlive NVDA if it is killed uncleanly",
+				exc_info=True,
+			)
+			return None
+		return cls(handle, kernel32)
+
+	def assign(self, process_handle: int) -> bool:
+		"""Put an already spawned process into the job.  True if it is now covered."""
+		with self._lock:
+			if self._handle is None:
+				return False
+			try:
+				if not self._kernel32.AssignProcessToJobObject(self._handle, process_handle):
+					raise ctypes.WinError(ctypes.get_last_error())
+			except Exception:
+				# Nested jobs need Windows 8 or newer.  Older systems, or a job
+				# NVDA itself sits in that forbids nesting, land here.
+				LOGGER.warning(
+					"Could not assign the Eloquence Host Process to the Job Object;"
+					" it will not be killed automatically if NVDA dies uncleanly",
+					exc_info=True,
+				)
+				return False
+		return True
+
+	def close(self) -> None:
+		"""Close the job handle, terminating anything still inside it.
+
+		Nothing in the add-on calls this: the handle is meant to stay open for the
+		life of the NVDA process so the kernel does the killing.  It exists so the
+		behaviour can be exercised in tests.
+		"""
+		with self._lock:
+			handle, self._handle = self._handle, None
+		if handle is not None:
+			self._kernel32.CloseHandle(handle)

--- a/tests/test_host_job.py
+++ b/tests/test_host_job.py
@@ -1,0 +1,101 @@
+import importlib.util
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+
+requires_windows = unittest.skipUnless(sys.platform == "win32", "Job Objects are Windows only")
+
+
+def _load_module(name, filename):
+	"""Import a synthDrivers module with the NVDA-only imports stubbed out."""
+	config_module = types.ModuleType("config")
+	config_module.conf = {}
+	nvwave_module = types.ModuleType("nvwave")
+	nvwave_module.WavePlayer = object
+	build_version_module = types.ModuleType("buildVersion")
+	build_version_module.version_year = 2026
+
+	stubs = {
+		"config": config_module,
+		"nvwave": nvwave_module,
+		"buildVersion": build_version_module,
+	}
+	previous = {stub: sys.modules.get(stub) for stub in stubs}
+	sys.modules.update(stubs)
+	module_name = f"addon.synthDrivers.{name}"
+	try:
+		path = Path(__file__).parents[1] / "addon" / "synthDrivers" / filename
+		spec = importlib.util.spec_from_file_location(module_name, path)
+		module = importlib.util.module_from_spec(spec)
+		sys.modules[module_name] = module
+		spec.loader.exec_module(module)
+		return module
+	finally:
+		sys.modules.pop(module_name, None)
+		for stub, old_module in previous.items():
+			if old_module is None:
+				sys.modules.pop(stub, None)
+			else:
+				sys.modules[stub] = old_module
+
+
+class HostJobTests(unittest.TestCase):
+	"""The Job Object has to outlive an Eloquence Host Process that never cooperates."""
+
+	@requires_windows
+	def test_closing_the_job_kills_an_assigned_process(self):
+		job_module = _load_module("_eloquence_job_test", "_eloquence_job.py")
+		job = job_module.HostJob.create()
+		self.assertIsNotNone(job, "Windows refused to create a Job Object")
+		# Stands in for an Eloquence Host Process wedged inside the Eloquence
+		# Engine: it will not
+		# exit on its own within the lifetime of this test.
+		proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+		try:
+			self.assertTrue(job.assign(int(proc._handle)))
+			self.assertIsNone(proc.poll(), "helper exited before the job was closed")
+			# Closing the last handle is what NVDA dying does for us.  The exit
+			# code a job close leaves behind is unspecified, so only the fact that
+			# the sleep never ran to completion is worth asserting.
+			job.close()
+			proc.wait(timeout=10)
+			self.assertIsNotNone(proc.poll())
+		finally:
+			if proc.poll() is None:
+				proc.kill()
+				proc.wait(timeout=10)
+
+	@requires_windows
+	def test_assign_after_close_is_refused(self):
+		job_module = _load_module("_eloquence_job_test", "_eloquence_job.py")
+		job = job_module.HostJob.create()
+		self.assertIsNotNone(job)
+		job.close()
+		self.assertFalse(job.assign(0))
+
+	@requires_windows
+	def test_close_is_idempotent(self):
+		job_module = _load_module("_eloquence_job_test", "_eloquence_job.py")
+		job = job_module.HostJob.create()
+		self.assertIsNotNone(job)
+		job.close()
+		job.close()
+
+	def test_a_missing_job_does_not_block_startup(self):
+		"""The backstop is best effort; losing it must not break speech."""
+		client_module = _load_module("_eloquence_job_client_test", "_eloquence.py")
+		client = client_module.EloquenceHostClient()
+		original_create = client_module._job.HostJob.create
+		client_module._job.HostJob.create = staticmethod(lambda: None)
+		try:
+			# Would raise if _adopt_into_job did not tolerate a job it never got.
+			client._adopt_into_job(object())
+		finally:
+			client_module._job.HostJob.create = original_create
+		self.assertIsNone(client._job)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Problem

#142 fixed the **cooperative** shutdown path: `SynthDriver.terminate()` now reaches `_eloquence.terminate()`, the Synth Driver side sends `delete` over the Host Channel, and `shutdown()` waits `HOST_EXIT_TIMEOUT` so the onefile PyInstaller bootloader can remove its `_MEI` directory.

That handshake cannot run when NVDA never gets the chance to send it:

- NVDA crashes
- NVDA is killed with `taskkill /f` (common when a screen reader wedges)
- The Eloquence Host Process is blocked inside an `ECI.DLL` call and never returns to `recv()` to see the command
- The Host Channel half-opens across sleep/hibernate — no `SO_KEEPALIVE` is set, so TCP holds a dead peer connection indefinitely

In each case the Eloquence Host Process is orphaned, holding an Eloquence Engine handle and often the output device, until someone spots it in Task Manager.

## Change

Spawned processes are assigned to a Windows Job Object created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. The Synth Driver side holds the only handle, so when the NVDA process goes away for **any** reason the kernel closes it and terminates whatever remains in the job. No cooperation from the Eloquence Host Process is required, so this works even when it is wedged inside `ECI.DLL`.

- `addon/synthDrivers/_eloquence_job.py` — new, self-contained `HostJob` wrapper over `CreateJobObjectW` / `SetInformationJobObject` / `AssignProcessToJobObject`
- `addon/synthDrivers/_eloquence.py` — `EloquenceHostClient._adopt_into_job()`, called from `ensure_started()` right after `Popen`

## Deliberate constraints

**It is a backstop, never the normal shutdown path.** A job kill is `TerminateProcess`, which leaves the `_MEI` directory behind — precisely what #142's cooperative handshake exists to avoid. `shutdown()` is untouched, and the add-on never calls `close()` on the handle.

**Every failure is logged and ignored.** A missing backstop must not stop Eloquence speaking, so `create()` returns `None` and `assign()` returns `False` rather than raising. Nested jobs need Windows 8+, which is well below NVDA's floor, but a job NVDA itself sits in that forbids nesting would land in that path.

**The job is created once per `EloquenceHostClient` and reused,** so switching away from the synth and back re-adopts the new process into the same job rather than leaking a handle per spawn.

**Assignment happens before the Host Channel is accepted,** so an Eloquence Host Process that starts but never connects — the read-only secure screen case `accept_authenticated` already warns about — is covered too.

## Testing

`tests/test_host_job.py`, 4 new tests. The load-bearing one spawns a 120-second sleep, assigns it, closes the job, and asserts the process is reaped — the orphan scenario end to end. Job-specific tests skip off Windows.

```
42 passed, 23 subtests passed
```

Also verified against the real wiring rather than the helper alone: calling `_adopt_into_job()` exactly as `ensure_started()` does, then closing the job, reaps the child.

## Notes for review

- There is a microsecond-scale race between `CreateProcess` returning and `AssignProcessToJobObject`. The textbook fix is `CREATE_SUSPENDED` + `ResumeThread`, but `subprocess` does not expose the child's thread handle, and the host does nothing but connect a socket in that window. I judged the complexity not worth it — happy to revisit.
- `_adopt_into_job` reads `proc._handle`. It is private, but it avoids the PID-reuse race that `OpenProcess(pid)` would introduce, and it has been stable in CPython for many years.
- `_eloquence_job.py` imports `ctypes.wintypes` at module level, which makes `_eloquence.py` Windows-only to import. NVDA is Windows-only and CI is `windows-2025`, so this seemed better than platform-guard scaffolding for a configuration the add-on cannot run in. Flagging it because it is a (small) new constraint on running the test suite.
- CI runs `runlint.bat` and `scons.bat` but never `pytest`, so these tests will not run there. Wiring that up felt out of scope for this PR.
- `Refs #141`. #141's literal complaint was fixed by #142; this is the complementary non-cooperative case, so I left it referenced rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
