### PR TITLE
Move the Host Channel from a loopback socket to a secured named pipe

### DIFF
--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import itertools
 import logging
 import os
-import socket
 
 import queue
 import shlex
@@ -25,7 +24,8 @@ LOGGER = logging.getLogger(__name__)
 
 HOST_EXECUTABLE = "eloquence_host32.exe"
 HOST_SCRIPT = "host_eloquence32.py"
-AUTH_KEY_BYTES = 16
+# How long to wait for the Eloquence Host Process to open the Host Channel.
+HOST_CONNECT_TIMEOUT = 10.0
 # Seconds to let the host exit on its own before we terminate it. A onefile
 # PyInstaller build only removes its _MEI temp directory on a clean exit.
 HOST_EXIT_TIMEOUT = 3.0
@@ -181,7 +181,7 @@ AudioChunk = Tuple[bytes, Optional[int], bool, int]
 class HostProcess:
 	process: subprocess.Popen
 	connection: Any
-	listener: socket.socket
+	listener: _ipc.PipeListener
 
 
 class EloquenceHostClient:
@@ -208,26 +208,24 @@ class EloquenceHostClient:
 		if self._host:
 			return
 		addon_dir = os.path.abspath(os.path.dirname(__file__))
-		authkey = os.urandom(AUTH_KEY_BYTES)
 		listener = _ipc.create_listener()
-		port = listener.getsockname()[1]
 		cmd = list(self._resolve_host_executable(addon_dir))
 		cmd.extend(
 			[
-				"--address",
-				f"127.0.0.1:{port}",
-				"--authkey",
-				authkey.hex(),
+				"--pipe",
+				listener.name,
 				"--log-dir",
 				addon_dir,
 			]
 		)
 		LOGGER.info("Launching Eloquence host: %s", cmd)
 		proc = subprocess.Popen(cmd, cwd=addon_dir)
+		# Must precede accept(): the Host Channel identifies its peer by asking
+		# whether that process is in this job.
 		self._adopt_into_job(proc)
 		try:
-			conn = _ipc.accept_authenticated(listener, authkey)
-		except (TimeoutError, OSError) as exc:
+			conn = listener.accept(self._job, HOST_CONNECT_TIMEOUT)
+		except (_ipc.HostChannelError, OSError) as exc:
 			LOGGER.error("Eloquence host failed to connect: %s", exc)
 			exit_code = proc.poll()
 			if exit_code is not None:
@@ -323,16 +321,9 @@ class EloquenceHostClient:
 		while True:
 			try:
 				message = connection.recv()
-			except socket.timeout:
-				if self._host and self._host.process.poll() is not None:
-					LOGGER.error("Host process exited (code %s)", self._host.process.returncode)
-					for msg_id, event in list(self._pending.items()):
-						self._responses[msg_id] = {"error": "hostExited"}
-						event.set()
-					self._pending.clear()
-					break
-				continue  # Host still alive, just busy
 			except (EOFError, ConnectionAbortedError, OSError):
+				# A dead Eloquence Host Process breaks the pipe immediately, so
+				# this covers the exit the socket transport needed a poll to spot.
 				LOGGER.info("Host connection closed")
 				for msg_id, event in list(self._pending.items()):
 					self._responses[msg_id] = {"error": "connectionClosed"}
@@ -543,6 +534,7 @@ langs = {
 	"jpn": (524288, "Japanese"),  # 0x00080000
 	"kor": (655360, "Korean"),
 }  # 0x000A0000
+
 
 def _ascii_safe_dir(directory):
 	"""Return *directory* as an ASCII path the ANSI ECI engine can open, or ``None``.

--- a/addon/synthDrivers/_eloquence_ipc.py
+++ b/addon/synthDrivers/_eloquence_ipc.py
@@ -1,96 +1,337 @@
-"""Lightweight IPC helpers for the Eloquence host communication."""
+"""Host Channel transport: a local named pipe restricted to this user.
+
+The Host Channel used to be a loopback TCP socket on an ephemeral port, guarded
+by a random key that the Synth Driver side passed to the Eloquence Host Process
+on its command line.  A process's command line is readable by anyone -- a single
+``Get-CimInstance Win32_Process`` query hands over both the port and the key --
+so any local process could connect to the port, present the key, and be accepted
+as the Eloquence Host Process.  Everything the Synth Driver side then received
+went through ``pickle.loads``, which makes that an arbitrary code execution path
+into NVDA.
+
+A named pipe removes the shared secret rather than hiding it better:
+
+* The pipe is created with a DACL granting access only to the account NVDA runs
+  as, plus LOCAL SYSTEM.  No other user, and no lower-integrity process, can
+  open it at all.
+* ``FILE_FLAG_FIRST_PIPE_INSTANCE`` means creation fails if the name already
+  exists, so nothing can squat the name and impersonate the listener.  The name
+  itself carries 128 bits of randomness, so it cannot be guessed either.
+* Whoever connects is checked against the Job Object that the Synth Driver side
+  puts every Eloquence Host Process into (see ``_eloquence_job``).  That is a
+  kernel-answered question about a process we launched, not a secret anyone can
+  read and replay.
+
+Nothing is written to the command line that helps an attacker: the pipe name is
+useless without the ability to open the pipe and pass the job check.
+"""
 
 from __future__ import annotations
 
+import ctypes
+import logging
+import os
 import pickle
-import socket
 import struct
 import threading
-from typing import Any, Tuple
+import time
+import _winapi
+from ctypes import wintypes
+from typing import Any, Optional
+
+LOGGER = logging.getLogger(__name__)
 
 _HEADER_STRUCT = struct.Struct("!I")
 
+_PIPE_PREFIX = r"\\.\pipe\eloquence-host-"
+_PIPE_NAME_BYTES = 16
+# Audio Chunks are a little over 6 KB, so this holds several without blocking
+# the Eloquence Host Process mid-synthesis.
+_PIPE_BUFFER_BYTES = 65536
+# PIPE_TYPE_BYTE, PIPE_READMODE_BYTE and PIPE_WAIT are all zero.  Byte mode keeps
+# the length-prefixed framing below in charge of message boundaries.
+_PIPE_MODE_BYTE_BLOCKING = 0
+_SDDL_REVISION_1 = 1
+_TOKEN_QUERY = 0x0008
+_TOKEN_USER = 1
 
-class IpcConnection:
-	"""Simple length-prefixed message channel built on sockets."""
+# Errors that mean the far end is gone rather than something we can retry.
+_DISCONNECTED = frozenset(
+	{
+		_winapi.ERROR_BROKEN_PIPE,  # 109, peer closed or exited
+		232,  # ERROR_NO_DATA, the pipe is being closed
+		233,  # ERROR_PIPE_NOT_CONNECTED
+		6,  # ERROR_INVALID_HANDLE, we closed underneath an in-flight operation
+	}
+)
 
-	def __init__(self, sock: socket.socket):
-		self._sock = sock
+
+class HostChannelError(RuntimeError):
+	"""The Host Channel could not be established."""
+
+
+def _advapi32() -> ctypes.WinDLL:
+	advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+	advapi32.OpenProcessToken.argtypes = [wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
+	advapi32.OpenProcessToken.restype = wintypes.BOOL
+	advapi32.GetTokenInformation.argtypes = [
+		wintypes.HANDLE,
+		ctypes.c_int,
+		wintypes.LPVOID,
+		wintypes.DWORD,
+		ctypes.POINTER(wintypes.DWORD),
+	]
+	advapi32.GetTokenInformation.restype = wintypes.BOOL
+	advapi32.ConvertSidToStringSidW.argtypes = [wintypes.LPVOID, ctypes.POINTER(wintypes.LPWSTR)]
+	advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+	advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = [
+		wintypes.LPCWSTR,
+		wintypes.DWORD,
+		ctypes.POINTER(wintypes.LPVOID),
+		ctypes.POINTER(wintypes.DWORD),
+	]
+	advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.restype = wintypes.BOOL
+	return advapi32
+
+
+def _kernel32() -> ctypes.WinDLL:
+	kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+	kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+	kernel32.GetNamedPipeClientProcessId.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.ULONG)]
+	kernel32.GetNamedPipeClientProcessId.restype = wintypes.BOOL
+	kernel32.DisconnectNamedPipe.argtypes = [wintypes.HANDLE]
+	kernel32.DisconnectNamedPipe.restype = wintypes.BOOL
+	kernel32.LocalFree.argtypes = [wintypes.LPVOID]
+	kernel32.LocalFree.restype = wintypes.LPVOID
+	kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+	kernel32.CloseHandle.restype = wintypes.BOOL
+	return kernel32
+
+
+class _SECURITY_ATTRIBUTES(ctypes.Structure):
+	_fields_ = [
+		("nLength", wintypes.DWORD),
+		("lpSecurityDescriptor", wintypes.LPVOID),
+		("bInheritHandle", wintypes.BOOL),
+	]
+
+
+def _current_user_sid(advapi32: ctypes.WinDLL, kernel32: ctypes.WinDLL) -> str:
+	"""Return the SID string of the account this process runs as."""
+	token = wintypes.HANDLE()
+	if not advapi32.OpenProcessToken(kernel32.GetCurrentProcess(), _TOKEN_QUERY, ctypes.byref(token)):
+		raise ctypes.WinError(ctypes.get_last_error())
+	try:
+		size = wintypes.DWORD()
+		# First call fails with ERROR_INSUFFICIENT_BUFFER purely to size the buffer.
+		advapi32.GetTokenInformation(token, _TOKEN_USER, None, 0, ctypes.byref(size))
+		buffer = ctypes.create_string_buffer(size.value)
+		if not advapi32.GetTokenInformation(token, _TOKEN_USER, buffer, size, ctypes.byref(size)):
+			raise ctypes.WinError(ctypes.get_last_error())
+		# TOKEN_USER starts with a SID_AND_ATTRIBUTES whose first member is the PSID.
+		sid = ctypes.cast(buffer, ctypes.POINTER(ctypes.c_void_p))[0]
+		text = wintypes.LPWSTR()
+		if not advapi32.ConvertSidToStringSidW(sid, ctypes.byref(text)):
+			raise ctypes.WinError(ctypes.get_last_error())
+		try:
+			return text.value
+		finally:
+			kernel32.LocalFree(text)
+	finally:
+		kernel32.CloseHandle(token)
+
+
+def _owner_only_security_attributes(advapi32, kernel32):
+	"""Build SECURITY_ATTRIBUTES granting this user and SYSTEM, and nobody else.
+
+	Returned alongside the security descriptor so the caller can keep a reference
+	for as long as the SECURITY_ATTRIBUTES is in use and free it afterwards.
+	"""
+	sid = _current_user_sid(advapi32, kernel32)
+	# D:P is a protected DACL, so nothing is inherited in; the two ACEs grant
+	# GENERIC_ALL to us and to LOCAL SYSTEM.  On a secure screen NVDA already
+	# runs as SYSTEM, which simply makes the two entries identical.
+	sddl = "D:P(A;;GA;;;{})(A;;GA;;;SY)".format(sid)
+	descriptor = wintypes.LPVOID()
+	if not advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+		sddl,
+		_SDDL_REVISION_1,
+		ctypes.byref(descriptor),
+		None,
+	):
+		raise ctypes.WinError(ctypes.get_last_error())
+	attributes = _SECURITY_ATTRIBUTES(
+		ctypes.sizeof(_SECURITY_ATTRIBUTES),
+		descriptor,
+		False,
+	)
+	return attributes, descriptor
+
+
+def _as_disconnect(exc: OSError) -> BaseException:
+	"""Translate a dead-peer Windows error into EOFError, leaving others alone."""
+	if getattr(exc, "winerror", None) in _DISCONNECTED:
+		return EOFError(str(exc))
+	return exc
+
+
+class PipeConnection:
+	"""Length-prefixed pickle framing over an overlapped named pipe handle.
+
+	The Synth Driver side reads on its receiver thread while sending Host
+	Commands from another, which is why every operation gets its own OVERLAPPED:
+	a read in flight does not block a concurrent write.  ``_send_lock`` keeps
+	concurrent senders from interleaving their frames.
+	"""
+
+	def __init__(self, handle: int):
+		self._handle: Optional[int] = handle
 		self._send_lock = threading.Lock()
 
 	def send(self, payload: Any) -> None:
 		data = pickle.dumps(payload, protocol=4)
-		header = _HEADER_STRUCT.pack(len(data))
+		frame = _HEADER_STRUCT.pack(len(data)) + data
 		with self._send_lock:
-			self._sock.sendall(header)
-			self._sock.sendall(data)
+			handle = self._handle
+			if handle is None:
+				raise EOFError("Host Channel is closed")
+			try:
+				overlapped, _err = _winapi.WriteFile(handle, frame, True)
+				written, _err = overlapped.GetOverlappedResult(True)
+			except OSError as exc:
+				raise _as_disconnect(exc) from exc
+			if written != len(frame):
+				raise EOFError("Host Channel accepted only part of a frame")
 
 	def recv(self) -> Any:
-		header = _recv_exact(self._sock, _HEADER_STRUCT.size)
-		if not header:
-			raise EOFError
-		(length,) = _HEADER_STRUCT.unpack(header)
-		data = _recv_exact(self._sock, length)
-		return pickle.loads(data)
+		(length,) = _HEADER_STRUCT.unpack(self._read_exact(_HEADER_STRUCT.size))
+		return pickle.loads(self._read_exact(length))
 
 	def close(self) -> None:
-		try:
-			self._sock.shutdown(socket.SHUT_RDWR)
-		except OSError:
-			pass
-		self._sock.close()
+		handle, self._handle = self._handle, None
+		if handle is not None:
+			try:
+				_winapi.CloseHandle(handle)
+			except OSError:
+				pass
+
+	def _read_exact(self, length: int) -> bytes:
+		chunks = []
+		remaining = length
+		while remaining:
+			handle = self._handle
+			if handle is None:
+				raise EOFError("Host Channel is closed")
+			try:
+				overlapped, _err = _winapi.ReadFile(handle, remaining, True)
+				overlapped.GetOverlappedResult(True)
+			except OSError as exc:
+				raise _as_disconnect(exc) from exc
+			chunk = overlapped.getbuffer()
+			if not chunk:
+				raise EOFError("Host Channel returned no data")
+			chunks.append(chunk)
+			remaining -= len(chunk)
+		return b"".join(chunks)
 
 
-def create_listener() -> socket.socket:
-	sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-	sock.bind(("127.0.0.1", 0))
-	sock.listen(1)
-	return sock
+class PipeListener:
+	"""The Synth Driver side of the Host Channel, before anything connects."""
+
+	def __init__(self, handle: int, name: str, kernel32: ctypes.WinDLL, descriptor):
+		self._handle: Optional[int] = handle
+		self._kernel32 = kernel32
+		# Kept alive only so the security descriptor outlives the pipe handle.
+		self._descriptor = descriptor
+		self.name = name
+
+	def accept(self, job, timeout: float) -> PipeConnection:
+		"""Wait for the Eloquence Host Process to connect and hand over the pipe.
+
+		Anything that connects but is not in *job* is disconnected and we keep
+		waiting, so a local process cannot take the Host Channel by connecting
+		first, nor deny it to the real Eloquence Host Process by holding the
+		single instance.
+		"""
+		deadline = time.monotonic() + timeout
+		while True:
+			remaining = deadline - time.monotonic()
+			if remaining <= 0:
+				raise HostChannelError(
+					f"Eloquence Host Process did not connect within {timeout}s. "
+					"It may have crashed on startup (e.g. read-only secure screen)."
+				)
+			self._wait_for_client(remaining)
+			pid = self._client_pid()
+			if job is None:
+				# Job creation already logged a warning of its own.  Accepting is
+				# no weaker than the loopback socket this replaced, and refusing
+				# would stop Eloquence speaking outright.
+				LOGGER.warning("No Job Object to check the Host Channel peer against; accepting pid %s", pid)
+				return self._hand_over()
+			if job.contains(pid):
+				return self._hand_over()
+			LOGGER.error(
+				"Rejecting Host Channel connection from pid %s: not a process we launched",
+				pid,
+			)
+			self._disconnect()
+
+	def close(self) -> None:
+		handle, self._handle = self._handle, None
+		if handle is not None:
+			try:
+				_winapi.CloseHandle(handle)
+			except OSError:
+				pass
+		self._descriptor = None
+
+	# ------------------------------------------------------------------
+	def _wait_for_client(self, timeout: float) -> None:
+		handle = self._handle
+		if handle is None:
+			raise HostChannelError("Host Channel listener is closed")
+		overlapped = _winapi.ConnectNamedPipe(handle, overlapped=True)
+		result = _winapi.WaitForMultipleObjects([overlapped.event], False, int(timeout * 1000))
+		if result != _winapi.WAIT_OBJECT_0:
+			overlapped.cancel()
+			raise HostChannelError(
+				f"Eloquence Host Process did not connect within {timeout:.1f}s. "
+				"It may have crashed on startup (e.g. read-only secure screen)."
+			)
+		overlapped.GetOverlappedResult(True)
+
+	def _client_pid(self) -> int:
+		pid = wintypes.ULONG()
+		if not self._kernel32.GetNamedPipeClientProcessId(self._handle, ctypes.byref(pid)):
+			raise ctypes.WinError(ctypes.get_last_error())
+		return int(pid.value)
+
+	def _disconnect(self) -> None:
+		if self._handle is not None:
+			self._kernel32.DisconnectNamedPipe(self._handle)
+
+	def _hand_over(self) -> PipeConnection:
+		"""Give the pipe handle to a PipeConnection, which owns it from now on."""
+		handle, self._handle = self._handle, None
+		self._descriptor = None
+		return PipeConnection(handle)
 
 
-def accept_authenticated(listener: socket.socket, authkey: bytes, timeout: float = 10.0) -> IpcConnection:
-	listener.settimeout(timeout)
-	try:
-		conn, _ = listener.accept()
-	except socket.timeout:
-		raise TimeoutError(
-			f"Eloquence host process did not connect within {timeout}s. "
-			"It may have crashed on startup (e.g. read-only secure screen)."
-		)
-	finally:
-		listener.settimeout(None)
-	_authenticate_server(conn, authkey)
-	conn.settimeout(10.0)  # Receiver thread will get socket.timeout after 10s of silence
-	return IpcConnection(conn)
-
-
-def connect_to_listener(address: Tuple[str, int], authkey: bytes) -> IpcConnection:
-	sock = socket.create_connection(address)
-	_send_all(sock, authkey)
-	sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-	return IpcConnection(sock)
-
-
-def _authenticate_server(sock: socket.socket, authkey: bytes) -> None:
-	data = _recv_exact(sock, len(authkey))
-	if data != authkey:
-		sock.close()
-		raise ConnectionError("authentication failed")
-	sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-
-
-def _recv_exact(sock: socket.socket, length: int) -> bytes:
-	remaining = length
-	chunks = []
-	while remaining:
-		chunk = sock.recv(remaining)
-		if not chunk:
-			raise EOFError
-		chunks.append(chunk)
-		remaining -= len(chunk)
-	return b"".join(chunks)
-
-
-def _send_all(sock: socket.socket, data: bytes) -> None:
-	sock.sendall(data)
+def create_listener() -> PipeListener:
+	"""Create the Host Channel end that the Eloquence Host Process connects to."""
+	advapi32 = _advapi32()
+	kernel32 = _kernel32()
+	attributes, descriptor = _owner_only_security_attributes(advapi32, kernel32)
+	name = _PIPE_PREFIX + os.urandom(_PIPE_NAME_BYTES).hex()
+	handle = _winapi.CreateNamedPipe(
+		name,
+		_winapi.PIPE_ACCESS_DUPLEX | _winapi.FILE_FLAG_FIRST_PIPE_INSTANCE | _winapi.FILE_FLAG_OVERLAPPED,
+		_PIPE_MODE_BYTE_BLOCKING,
+		1,
+		_PIPE_BUFFER_BYTES,
+		_PIPE_BUFFER_BYTES,
+		0,
+		ctypes.addressof(attributes),
+	)
+	return PipeListener(handle, name, kernel32, descriptor)

--- a/addon/synthDrivers/_eloquence_job.py
+++ b/addon/synthDrivers/_eloquence_job.py
@@ -36,6 +36,8 @@ LOGGER = logging.getLogger(__name__)
 _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
 # JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation
 _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+# The least privilege that still answers "is this process in my job?".
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
 # ULONG_PTR and SIZE_T are pointer sized; c_size_t is correct for both bitnesses.
 _ULONG_PTR = ctypes.c_size_t
@@ -90,6 +92,10 @@ def _kernel32() -> ctypes.WinDLL:
 	kernel32.SetInformationJobObject.restype = wintypes.BOOL
 	kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
 	kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+	kernel32.IsProcessInJob.argtypes = [wintypes.HANDLE, wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)]
+	kernel32.IsProcessInJob.restype = wintypes.BOOL
+	kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+	kernel32.OpenProcess.restype = wintypes.HANDLE
 	kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
 	kernel32.CloseHandle.restype = wintypes.BOOL
 	return kernel32
@@ -150,6 +156,39 @@ class HostJob:
 				)
 				return False
 		return True
+
+	def contains(self, pid: int) -> bool:
+		"""Is the process with *pid* one we put in this job?
+
+		This is how the Host Channel decides whether whoever connected to it is
+		really the Eloquence Host Process we launched.  Job membership survives
+		the onefile PyInstaller bootloader re-executing itself, which a plain
+		comparison against ``Popen.pid`` does not: the bootloader is the process
+		we spawn, the Python code that opens the Host Channel runs in the child
+		it starts, and that child inherits the job.
+		"""
+		with self._lock:
+			if self._handle is None:
+				return False
+			handle = self._handle
+			try:
+				process = self._kernel32.OpenProcess(
+					_PROCESS_QUERY_LIMITED_INFORMATION,
+					False,
+					pid,
+				)
+				if not process:
+					raise ctypes.WinError(ctypes.get_last_error())
+				try:
+					member = wintypes.BOOL()
+					if not self._kernel32.IsProcessInJob(process, handle, ctypes.byref(member)):
+						raise ctypes.WinError(ctypes.get_last_error())
+				finally:
+					self._kernel32.CloseHandle(process)
+			except Exception:
+				LOGGER.warning("Could not check job membership for pid %s", pid, exc_info=True)
+				return False
+		return bool(member)
 
 	def close(self) -> None:
 		"""Close the job handle, terminating anything still inside it.

--- a/host_eloquence32.py
+++ b/host_eloquence32.py
@@ -17,10 +17,11 @@ import argparse
 import logging
 import os
 import pickle
-import socket
 import struct
 import sys
 import threading
+import time
+import _winapi
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "eloquence"))
 from dataclasses import dataclass
@@ -39,45 +40,99 @@ from ctypes import (
 
 _HEADER_STRUCT = struct.Struct("!I")
 
+# Errors that mean the far end is gone rather than something we can retry.
+_DISCONNECTED = frozenset(
+	{
+		_winapi.ERROR_BROKEN_PIPE,  # 109, peer closed or exited
+		232,  # ERROR_NO_DATA, the pipe is being closed
+		233,  # ERROR_PIPE_NOT_CONNECTED
+		6,  # ERROR_INVALID_HANDLE, we closed underneath an in-flight operation
+	}
+)
+
 
 class IpcConnection:
-	"""Simple length-prefixed message channel built on sockets."""
+	"""Length-prefixed message channel over the Host Channel named pipe.
 
-	def __init__(self, sock: socket.socket):
-		self._sock = sock
+	The Synth Driver side creates the pipe with a DACL that admits only its own
+	account, so this end simply opens it.  Reads and writes are synchronous: the
+	Eloquence Host Process is single threaded, and blocking in ReadFile until the
+	next Host Command arrives is exactly the behaviour it wants.  When NVDA dies
+	the pipe breaks and ReadFile fails, which is what ends serve_forever().
+	"""
+
+	def __init__(self, handle):
+		self._handle = handle
 		self._send_lock = threading.Lock()
 
 	def send(self, payload):
 		data = pickle.dumps(payload, protocol=4)
-		header = _HEADER_STRUCT.pack(len(data))
+		frame = _HEADER_STRUCT.pack(len(data)) + data
 		with self._send_lock:
-			self._sock.sendall(header)
-			self._sock.sendall(data)
+			try:
+				written = _winapi.WriteFile(self._handle, frame)[0]
+			except OSError as exc:
+				raise _as_disconnect(exc) from exc
+			if written != len(frame):
+				raise EOFError("Host Channel accepted only part of a frame")
 
 	def recv(self):
-		header = self._recv_exact(_HEADER_STRUCT.size)
-		if not header:
-			raise EOFError
-		(length,) = _HEADER_STRUCT.unpack(header)
+		(length,) = _HEADER_STRUCT.unpack(self._recv_exact(_HEADER_STRUCT.size))
 		return pickle.loads(self._recv_exact(length))
 
 	def close(self):
-		try:
-			self._sock.shutdown(socket.SHUT_RDWR)
-		except OSError:
-			pass
-		self._sock.close()
+		handle, self._handle = self._handle, None
+		if handle is not None:
+			try:
+				_winapi.CloseHandle(handle)
+			except OSError:
+				pass
 
 	def _recv_exact(self, length):
 		chunks = []
 		remaining = length
 		while remaining:
-			chunk = self._sock.recv(remaining)
+			if self._handle is None:
+				raise EOFError("Host Channel is closed")
+			try:
+				chunk = _winapi.ReadFile(self._handle, remaining)[0]
+			except OSError as exc:
+				raise _as_disconnect(exc) from exc
 			if not chunk:
-				raise EOFError
+				raise EOFError("Host Channel returned no data")
 			chunks.append(chunk)
 			remaining -= len(chunk)
 		return b"".join(chunks)
+
+
+def _as_disconnect(exc):
+	"""Translate a dead-peer Windows error into EOFError, leaving others alone."""
+	if getattr(exc, "winerror", None) in _DISCONNECTED:
+		return EOFError(str(exc))
+	return exc
+
+
+def connect_to_host_channel(name, timeout=10.0):
+	"""Open the Host Channel the Synth Driver side is listening on."""
+	deadline = time.monotonic() + timeout
+	while True:
+		try:
+			handle = _winapi.CreateFile(
+				name,
+				_winapi.GENERIC_READ | _winapi.GENERIC_WRITE,
+				0,
+				_winapi.NULL,
+				_winapi.OPEN_EXISTING,
+				0,
+				_winapi.NULL,
+			)
+		except OSError as exc:
+			# Something else momentarily holds the single pipe instance.
+			if exc.winerror != _winapi.ERROR_PIPE_BUSY or time.monotonic() >= deadline:
+				raise
+			time.sleep(0.05)
+			continue
+		return IpcConnection(handle)
 
 
 def get_short_path(path):
@@ -565,21 +620,14 @@ class HostController:
 
 def main() -> None:
 	parser = argparse.ArgumentParser(description="Eloquence 32-bit helper")
-	parser.add_argument("--address", required=True)
-	parser.add_argument("--authkey", required=True)
+	parser.add_argument("--pipe", required=True, help="Host Channel named pipe to connect to")
 	parser.add_argument("--log-dir", default=None)
 	args = parser.parse_args()
 
 	configure_logging(args.log_dir)
-	LOGGER.info("Connecting to controller at %s", args.address)
+	LOGGER.info("Opening Host Channel at %s", args.pipe)
 
-	host, port_str = args.address.split(":")
-	address = (host, int(port_str))
-	authkey = bytes.fromhex(args.authkey)
-	sock = socket.create_connection(address)
-	sock.sendall(authkey)
-	sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-	conn = IpcConnection(sock)
+	conn = connect_to_host_channel(args.pipe)
 	controller = HostController(conn)
 	controller.serve_forever()
 

--- a/tests/test_host_pipe_channel.py
+++ b/tests/test_host_pipe_channel.py
@@ -1,0 +1,256 @@
+"""Tests for the named pipe Host Channel and the identity check that guards it."""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+requires_windows = unittest.skipUnless(sys.platform == "win32", "The Host Channel is Windows only")
+
+SYNTH_DRIVERS = Path(__file__).parents[1] / "addon" / "synthDrivers"
+
+
+def _load(filename):
+	"""Load a dependency-free synthDrivers module straight off disk."""
+	name = "eloquence_test_" + Path(filename).stem.lstrip("_")
+	spec = importlib.util.spec_from_file_location(name, SYNTH_DRIVERS / filename)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _client_source(pipe_name, body, ready_file=None):
+	"""Source for a child that opens the Host Channel, signals, then runs *body*.
+
+	The retry on ERROR_PIPE_BUSY mirrors the Eloquence Host Process: the pipe
+	allows a single instance, so a client that arrives while someone else holds
+	it has to wait rather than fail.
+	"""
+	preamble = textwrap.dedent(
+		"""
+		import _winapi, pickle, struct, time
+		deadline = time.monotonic() + 15
+		while True:
+		    try:
+		        h = _winapi.CreateFile(NAME, _winapi.GENERIC_READ | _winapi.GENERIC_WRITE, 0,
+		                               _winapi.NULL, _winapi.OPEN_EXISTING, 0, _winapi.NULL)
+		        break
+		    except OSError as exc:
+		        if exc.winerror != _winapi.ERROR_PIPE_BUSY or time.monotonic() >= deadline:
+		            raise
+		        time.sleep(0.02)
+		if READY:
+		    open(READY, "w").close()
+		def send(payload):
+		    data = pickle.dumps(payload, protocol=4)
+		    _winapi.WriteFile(h, struct.pack("!I", len(data)) + data)
+		"""
+	)
+	return preamble.replace("NAME", repr(pipe_name)).replace("READY", repr(ready_file)) + textwrap.dedent(
+		body
+	)
+
+
+class PipeChannelTests(unittest.TestCase):
+	@requires_windows
+	def setUp(self):
+		self.ipc = _load("_eloquence_ipc.py")
+		self.jobs = _load("_eloquence_job.py")
+		self.children = []
+		self.listener = None
+		self.job = None
+		self._temp = tempfile.TemporaryDirectory()
+
+	def tearDown(self):
+		for child in self.children:
+			if child.poll() is None:
+				child.kill()
+			child.wait(timeout=10)
+		if self.listener is not None:
+			self.listener.close()
+		if self.job is not None:
+			self.job.close()
+		self._temp.cleanup()
+
+	# ------------------------------------------------------------------
+	def _spawn(self, source, job=None):
+		child = subprocess.Popen([sys.executable, "-c", source])
+		self.children.append(child)
+		if job is not None:
+			# Assigning the process we spawned also covers any child it re-execs,
+			# which is how the onefile Eloquence Host Process actually starts.
+			job.assign(int(child._handle))
+		return child
+
+	def _ready_path(self, label):
+		return os.path.join(self._temp.name, label + ".ready")
+
+	def _wait_for_ready(self, path, timeout=15):
+		deadline = time.monotonic() + timeout
+		while time.monotonic() < deadline:
+			if os.path.exists(path):
+				return
+			time.sleep(0.02)
+		self.fail("client never reported that it opened the Host Channel")
+
+	# ------------------------------------------------------------------
+	@requires_windows
+	def test_the_pipe_name_cannot_be_squatted(self):
+		"""FILE_FLAG_FIRST_PIPE_INSTANCE is what stops a fake listener taking the name."""
+		import _winapi
+
+		self.listener = self.ipc.create_listener()
+		self.assertTrue(self.listener.name.startswith("\\\\.\\pipe\\eloquence-host-"))
+		with self.assertRaises(OSError):
+			_winapi.CreateNamedPipe(
+				self.listener.name,
+				_winapi.PIPE_ACCESS_DUPLEX | _winapi.FILE_FLAG_FIRST_PIPE_INSTANCE,
+				0,
+				1,
+				4096,
+				4096,
+				0,
+				_winapi.NULL,
+			)
+
+	@requires_windows
+	def test_the_pipe_is_readable_only_by_this_user_and_system(self):
+		"""Read the DACL back off the live pipe rather than trusting the SDDL we built."""
+		import ctypes
+		from ctypes import wintypes
+
+		SE_KERNEL_OBJECT = 6
+		DACL_SECURITY_INFORMATION = 0x00000004
+
+		advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+		kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+		self.listener = self.ipc.create_listener()
+
+		descriptor = wintypes.LPVOID()
+		status = advapi32.GetSecurityInfo(
+			wintypes.HANDLE(self.listener._handle),
+			SE_KERNEL_OBJECT,
+			DACL_SECURITY_INFORMATION,
+			None,
+			None,
+			None,
+			None,
+			ctypes.byref(descriptor),
+		)
+		self.assertEqual(status, 0, "GetSecurityInfo failed")
+		text = wintypes.LPWSTR()
+		self.assertTrue(
+			advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+				descriptor,
+				1,
+				DACL_SECURITY_INFORMATION,
+				ctypes.byref(text),
+				None,
+			)
+		)
+		sddl = text.value
+		kernel32.LocalFree(text)
+		kernel32.LocalFree(descriptor)
+
+		self.assertTrue(sddl.startswith("D:P"), f"DACL is not protected: {sddl}")
+		self.assertIn(";;;SY)", sddl, f"LOCAL SYSTEM was not granted access: {sddl}")
+		# Everyone, Authenticated Users, Users and World must not appear: those are
+		# the entries that would put the Host Channel back within reach of another
+		# account on the machine.
+		for trustee in (";;;WD)", ";;;AU)", ";;;BU)", ";;;IU)", ";;;AN)"):
+			self.assertNotIn(trustee, sddl, f"DACL grants {trustee} too broadly: {sddl}")
+
+	@requires_windows
+	def test_two_listeners_do_not_collide(self):
+		first = self.ipc.create_listener()
+		second = self.ipc.create_listener()
+		try:
+			self.assertNotEqual(first.name, second.name)
+		finally:
+			first.close()
+			second.close()
+
+	@requires_windows
+	def test_a_peer_in_the_job_is_accepted_and_frames_round_trip(self):
+		self.job = self.jobs.HostJob.create()
+		self.assertIsNotNone(self.job)
+		self.listener = self.ipc.create_listener()
+		self._spawn(
+			_client_source(self.listener.name, '\nsend({"greeting": "host"})\ntime.sleep(10)\n'),
+			job=self.job,
+		)
+		connection = self.listener.accept(self.job, timeout=15)
+		try:
+			self.assertEqual(connection.recv(), {"greeting": "host"})
+		finally:
+			connection.close()
+
+	@requires_windows
+	def test_a_peer_outside_the_job_is_rejected_and_the_real_one_still_gets_in(self):
+		"""The attack the loopback socket allowed: connect first, be believed."""
+		self.job = self.jobs.HostJob.create()
+		self.assertIsNotNone(self.job)
+		self.listener = self.ipc.create_listener()
+
+		# Not in the job, and it connects first.  Under the old transport it would
+		# have won simply by replaying the authkey read off the command line.
+		ready = self._ready_path("impostor")
+		impostor = self._spawn(
+			_client_source(
+				self.listener.name,
+				'\nsend({"greeting": "impostor"})\ntime.sleep(20)\n',
+				ready_file=ready,
+			)
+		)
+		self._wait_for_ready(ready)
+
+		self._spawn(
+			_client_source(self.listener.name, '\nsend({"greeting": "host"})\ntime.sleep(10)\n'),
+			job=self.job,
+		)
+		connection = self.listener.accept(self.job, timeout=20)
+		try:
+			self.assertEqual(connection.recv(), {"greeting": "host"})
+		finally:
+			connection.close()
+		self.assertIsNone(impostor.poll(), "the impostor should be disconnected, not killed")
+
+	@requires_windows
+	def test_accept_times_out_when_nothing_connects(self):
+		self.job = self.jobs.HostJob.create()
+		self.listener = self.ipc.create_listener()
+		with self.assertRaises(self.ipc.HostChannelError):
+			self.listener.accept(self.job, timeout=0.5)
+
+	@requires_windows
+	def test_a_dead_peer_reads_as_eof(self):
+		"""What ends the receiver loop now that there is no socket timeout poll."""
+		self.job = self.jobs.HostJob.create()
+		self.listener = self.ipc.create_listener()
+		child = self._spawn(
+			_client_source(self.listener.name, '\nsend({"greeting": "host"})\n'),
+			job=self.job,
+		)
+		connection = self.listener.accept(self.job, timeout=15)
+		try:
+			self.assertEqual(connection.recv(), {"greeting": "host"})
+			child.wait(timeout=10)
+			with self.assertRaises(EOFError):
+				connection.recv()
+		finally:
+			connection.close()
+
+	@requires_windows
+	def test_job_membership_rejects_an_unrelated_process(self):
+		self.job = self.jobs.HostJob.create()
+		outsider = self._spawn("import time; time.sleep(10)")
+		self.assertFalse(self.job.contains(outsider.pid))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Follows the transport discussion after #144. This is the security half: the orphan work is done, this removes the shared secret.

## The hole

The Host Channel was loopback TCP on an ephemeral port, guarded by a 16-byte key passed to the Eloquence Host Process on its **command line**:

```
eloquence_host32.exe --address 127.0.0.1:52341 --authkey 8f3a...  --log-dir ...
```

A command line is readable by any local process — one `Get-CimInstance Win32_Process` query yields both the port and the key. An attacker could connect, present the key, and win the race against the real host. `_receiver_loop` then feeds whatever arrives to `pickle.loads`, so that is an arbitrary code execution path into NVDA. The handshake was also one-way: `connect_to_listener` sent the key and trusted whoever answered.

## The fix

A named pipe with **no shared secret**:

- **DACL** granting only the account NVDA runs as, plus LOCAL SYSTEM. Read back off a live pipe, it is `D:P(A;;FA;;;S-1-5-21-…-1001)(A;;FA;;;SY)` — protected, two ACEs, nothing else. Another user or a lower-integrity process cannot open it at all.
- **`FILE_FLAG_FIRST_PIPE_INSTANCE`**, so creation fails if the name exists and nothing can squat it. The name carries 128 bits of randomness on top.
- **Peer identity from the kernel**: whoever connects is checked against the Job Object that #144 already puts every Eloquence Host Process into.

The pipe name still goes on the command line, and that is now harmless — it is useless without the ability to open the pipe and pass the job check.

## Why job membership and not `Popen.pid`

I tried the obvious check first and it fails. A onefile PyInstaller build **re-executes itself**: the process we spawn is the bootloader, the Python code that opens the Host Channel runs in the child it starts, and only that child shows up as the pipe client. Measured:

```
Popen.pid            : 63580
pipe client pid      : 62980   <- the re-exec'd child
PID check would pass : False
IsProcessInJob       : True    <- child inherited the job
outsider in job      : False
```

Job membership identifies the real host correctly and still rejects an unrelated same-user process. It is also the same mechanism that already guarantees the host dies with NVDA, so the two pieces reinforce each other.

## Behaviour changes worth reviewing

**A rejected peer does not end startup.** `accept()` disconnects it and keeps waiting until the timeout, so a local process can neither take the Host Channel by connecting first nor deny it to the real host by holding the single instance. There is a test for exactly that ordering.

**The socket-timeout poll in `_receiver_loop` is gone.** It existed to notice a host that had exited. A broken pipe raises immediately instead, and the existing disconnect branch already handles it. The old branch's other case — host alive but silent — did nothing but `continue`, so no behaviour is lost.

**The peer check is skipped if the Job Object could not be created**, with a warning, rather than refusing to speak. That is no weaker than the socket transport it replaces, which had no effective check either, and it keeps #144's rule that a missing backstop must never stop Eloquence speaking.

## ⚠️ Secure screen copies must be re-copied

`--address/--authkey` became `--pipe`, so a **stale `eloquence_host32.exe` in `systemConfig` will fail to start** — the old exe rejects the new argument. Anyone who has used *Copy Helper to System Config* needs to run it again after this lands. That is the same situation the existing one-time migration notice was added for; you may want to reuse that mechanism, and I have deliberately not touched it since the wording is user-facing and yours to choose.

## Testing

`tests/test_host_pipe_channel.py`, 8 new tests: the DACL read back off a live pipe, name-squatting refused, frames round-tripping, accept timeout, dead peer reading as EOF, job membership rejecting an outsider, and the load-bearing one — an impostor connecting **first** is rejected and the real in-job client still gets through.

Full suite: `67 passed`, plus one pre-existing failure (`test_host_shutdown.py::test_log_file_truncated_on_startup`, a `PermissionError` in tempfile cleanup) that also fails on master, unchanged by this PR — happy to fix separately.

Beyond unit tests, I ran the real thing end to end — actual `eloquence_host32.exe`, actual `ECI.DLL`, rebuilt via `build_host.cmd`:

```
pipe name : \.\pipe\eloquence-host-103212d1414d41e0ca194676b79d7c9d
initialize -> ['params', 'voiceParams']
audio events: 9  total bytes: 50886
shutting down...   host exited: True   host log size: 0
```

`scons.bat` packages cleanly and the new module is in the addon.

## Notes

- Overlapped I/O on the Synth Driver side (concurrent receiver-thread read and command-thread write on one handle); plain synchronous I/O in the host, which is single threaded and wants to block until the next Host Command.
- Byte-mode pipe, so the existing length-prefixed framing keeps owning message boundaries.
- `_winapi` covers the pipe calls; ctypes only for the DACL and `GetNamedPipeClientProcessId`.
- Dropped `connect_to_listener` from `_eloquence_ipc.py` — the host carries its own client half, so it was dead.
- This is arguably ADR-worthy given `docs/adr/`, but `docs/agents/domain.md` says ADRs get created lazily by `/grill-with-docs`, so I did not add one unilaterally. Say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
