### PR TITLE
Run the unit tests in CI, and fix what was stopping them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
         run: runlint.bat
         shell: cmd
 
+      # Runs before the proprietary fetch and the build on purpose: nothing in
+      # the suite needs ECI.DLL or the built host, so failures surface early.
+      - name: Unit tests
+        run: runpytest.bat
+        shell: cmd
+
       - name: Install MSYS2 / gettext
         uses: msys2/setup-msys2@v2
         with:

--- a/addon/synthDrivers/_eloquence.py
+++ b/addon/synthDrivers/_eloquence.py
@@ -544,6 +544,7 @@ langs = {
 	"kor": (655360, "Korean"),
 }  # 0x000A0000
 
+
 def _ascii_safe_dir(directory):
 	"""Return *directory* as an ASCII path the ANSI ECI engine can open, or ``None``.
 

--- a/addon/synthDrivers/_eloquence_text.py
+++ b/addon/synthDrivers/_eloquence_text.py
@@ -11,19 +11,23 @@ pause_re = re.compile(r"([a-zA-Z0-9]|\s)([,.:;?!)])(\2*?)(\s|[\\/]|$|$)")
 time_re = re.compile(r"(\d):(\d+):(\d+)")
 punctuation = b",.?:;)(?!"
 
-_ENGINE_ENCODINGS = MappingProxyType({
-	393216: "gb18030",
-	524288: "cp932",
-	655360: "cp949",
-})
+_ENGINE_ENCODINGS = MappingProxyType(
+	{
+		393216: "gb18030",
+		524288: "cp932",
+		655360: "cp949",
+	}
+)
 
-_BREAK_FACTORS = MappingProxyType({
-	10: 1,
-	43: 2,
-	60: 3,
-	75: 4,
-	85: 5,
-})
+_BREAK_FACTORS = MappingProxyType(
+	{
+		10: 1,
+		43: 2,
+		60: 3,
+		75: 4,
+		85: 5,
+	}
+)
 
 
 @dataclass(frozen=True)

--- a/addon/synthDrivers/_script_conversion.py
+++ b/addon/synthDrivers/_script_conversion.py
@@ -54,7 +54,9 @@ def _parse_opencc_table(path):
 			try:
 				key, values = line.split("\t", 1)
 			except ValueError as error:
-				raise ValueError(f"{path.name}:{line_number}: expected tab-separated key and values") from error
+				raise ValueError(
+					f"{path.name}:{line_number}: expected tab-separated key and values"
+				) from error
 			value = values.split(" ", 1)[0]
 			mappings[key] = value
 			max_key_length = max(max_key_length, len(key))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,13 @@ max-complexity = 15
 # getLanguage import is a side-effect check for NVDA environment detection
 "addon/synthDrivers/_eloquence_updater.py" = ["F401"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The suite imports host_eloquence32, site_scons and addon/ straight from the
+# repo root. "python -m pytest" puts the root on sys.path implicitly, but the
+# "pytest" console script does not, so say so rather than depend on how it is run.
+pythonpath = ["."]
+
 [tool.uv]
 default-groups = "all"
 environments = ["sys_platform == 'win32'"]

--- a/tests/test_host_dictionaries.py
+++ b/tests/test_host_dictionaries.py
@@ -20,7 +20,9 @@ class FakeDll:
 		self.calls.append(("setDict", handle, dictionary_handle))
 
 	def eciLoadDict(self, handle, dictionary_handle, index, path):
-		self.calls.append(("loadDict", handle, dictionary_handle, index, os.path.basename(path.decode("mbcs"))))
+		self.calls.append(
+			("loadDict", handle, dictionary_handle, index, os.path.basename(path.decode("mbcs")))
+		)
 
 	def eciSetParam(self, handle, param_id, value):
 		self.calls.append(("setParam", handle, param_id, value))

--- a/tests/test_host_shutdown.py
+++ b/tests/test_host_shutdown.py
@@ -157,20 +157,38 @@ class ConfigureLoggingTruncationTests(unittest.TestCase):
 		logging.getLogger().handlers.clear()
 
 	def tearDown(self):
+		self._close_new_handlers()
 		logging.getLogger().handlers = self._saved_handlers
+
+	def _close_new_handlers(self):
+		"""Close handlers configure_logging added, releasing the log file.
+
+		basicConfig() installs a FileHandler that holds eloquence-host.log open,
+		and Windows will not delete a file that still has an open handle.
+		Dropping the handler without closing it leaves the log locked.
+		"""
+		root = logging.getLogger()
+		for handler in root.handlers:
+			if handler not in self._saved_handlers:
+				handler.close()
 
 	def test_log_file_truncated_on_startup(self):
 		with tempfile.TemporaryDirectory() as log_dir:
-			log_path = os.path.join(log_dir, "eloquence-host.log")
-			# Pre-write some stale content
-			with open(log_path, "w") as f:
-				f.write("stale error log from previous session\n" * 100)
-			self.assertGreater(os.path.getsize(log_path), 0)
+			try:
+				log_path = os.path.join(log_dir, "eloquence-host.log")
+				# Pre-write some stale content
+				with open(log_path, "w") as f:
+					f.write("stale error log from previous session\n" * 100)
+				self.assertGreater(os.path.getsize(log_path), 0)
 
-			# Reconfigure — should truncate
-			host.configure_logging(log_dir)
-			# The file should now be empty (no errors logged yet at level ERROR)
-			self.assertEqual(os.path.getsize(log_path), 0)
+				# Reconfigure — should truncate
+				host.configure_logging(log_dir)
+				# The file should now be empty (no errors logged yet at level ERROR)
+				self.assertEqual(os.path.getsize(log_path), 0)
+			finally:
+				# Has to happen before TemporaryDirectory removes the file, and
+				# still has to happen when an assertion above fails.
+				self._close_new_handlers()
 
 	def test_log_file_without_dir(self):
 		# Must not crash when log_dir is None

--- a/tests/test_temp_prosody.py
+++ b/tests/test_temp_prosody.py
@@ -112,8 +112,7 @@ class TempProsodyAcrossVoiceSwitchTests(unittest.TestCase):
 		self.assertEqual(
 			values[-1],
 			(BASE_PITCH, False),
-			"after a prosody revert the language change must leave pitch at "
-			"base: %r" % values,
+			"after a prosody revert the language change must leave pitch at base: %r" % values,
 		)
 
 	def test_stop_clears_pending_prosody(self):
@@ -125,8 +124,7 @@ class TempProsodyAcrossVoiceSwitchTests(unittest.TestCase):
 		self.assertEqual(
 			values[-1],
 			(BASE_PITCH, False),
-			"cancelled speech must not leak its temporary pitch into the "
-			"next voice switch: %r" % values,
+			"cancelled speech must not leak its temporary pitch into the next voice switch: %r" % values,
 		)
 
 	def test_reapplied_pitch_clamped_to_param_max(self):


### PR DESCRIPTION
Three things from the #145 review notes. They turned out to be one thread: the suite could not go into CI until the other two were fixed.

## `runpytest.bat` did not work

The script already existed — it just failed, which is presumably why it was never wired up:

```
ModuleNotFoundError: No module named 'site_scons'
ModuleNotFoundError: No module named 'addon'
!!! Interrupted: 7 errors during collection !!!
```

The `pytest` console script does not put the repo root on `sys.path`; `python -m pytest` does. That is why the suite passed when run one way and collapsed when run the other. Fixed declaratively in `pyproject.toml` rather than by changing the batch file, so plain `pytest`, `uv run pytest`, IDE runners and CI all behave the same:

```toml
[tool.pytest.ini_options]
testpaths = ["tests"]
pythonpath = ["."]
```

## The `PermissionError`

`configure_logging` calls `basicConfig(filename=...)`, which installs a `FileHandler` that holds `eloquence-host.log` open. The test dropped the handler from the logger but never closed it, so `TemporaryDirectory` could not delete the file and cleanup raised `PermissionError` on Windows.

Handlers are now closed before the directory is removed, in a `finally` so that a failing assertion still releases the file and reports the real failure instead of being masked by the cleanup error. `tearDown` closes them too, for the other test in the class.

## Format drift

Five files had drifted from `ruff format`: `_eloquence.py`, `_eloquence_text.py`, `_script_conversion.py`, `test_host_dictionaries.py`, `test_temp_prosody.py`. Cosmetic only — mostly one blank line and a few dict-literal wrappings.

I did **not** add `ruff format --check` to `runlint.bat`. The tree is clean now, so it would pass, but turning formatting into a merge gate is a policy call rather than a cleanup, and it is one flag whenever you want it. Without it the drift will come back.

## CI placement

```yaml
      - name: Unit tests
        run: runpytest.bat
        shell: cmd
```

Placed straight after Lint, before `fetch_eci.py` and the PyInstaller build. Nothing in the suite touches `ECI.DLL` or the built host — I checked every reference, they are all temp paths and fixture strings — so there is no reason to make a test failure wait on the build.

## Verification

The exact CI gate sequence, run locally in order:

```
uv lock --check   -> Resolved 15 packages
runlint.bat       -> All checks passed!            exit 0
runpytest.bat     -> 60 passed in 1.17s            exit 0
```

`ruff format --check .` reports 24 files already formatted. The `PermissionError` that failed on master is gone.

Note this stacks with #145 in effect but not in git: this branch is off master and touches different files, so they merge in either order. Once both are in, CI will run the 8 new Host Channel tests too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
