### PR TITLE
Clarify dictionary update progress and completion

### DIFF
--- a/addon/synthDrivers/_eloquence_updater.py
+++ b/addon/synthDrivers/_eloquence_updater.py
@@ -102,7 +102,8 @@ class EloquenceUpdateManager:
 						downloaded += len(buffer)
 						f.write(buffer)
 						if total_size > 0:
-							percent = int(downloaded * 100 / total_size)
+							# Reserve completion for the caller after the downloaded file is closed.
+							percent = min(99, int(downloaded * 100 / total_size))
 							# Translators: Text in the progress dialog used during add-on update.
 							if not progress_callback(
 								percent, _("Downloading update... {percent}%").format(percent=percent)

--- a/addon/synthDrivers/eloquence.py
+++ b/addon/synthDrivers/eloquence.py
@@ -141,7 +141,8 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 				config.conf.get("eloquence", {}).get("dictionary_name", "Alternative IBM TTS Dictionaries")
 			)
 
-			self.updateButton = sHelper.addItem(wx.Button(self, label=_("Check for updates")))
+			# Translators: Button that downloads and applies updates to the selected Eloquence dictionaries.
+			self.updateButton = sHelper.addItem(wx.Button(self, label=_("Update Dictionaries")))
 			self.Bind(wx.EVT_BUTTON, self.onUpdate, self.updateButton)
 			# When NVDA is running in secure mode, one should not be able to save any setting to disk.
 			if globalVars.appArgs.secure:
@@ -367,7 +368,11 @@ class EloquenceSettingsPanel(gui.settingsDialogs.SettingsPanel):
 				return cont
 
 			addon_path = manager.download_update(download_url, download_progress)
-			progress.Update(100, _("Download complete"))
+			progress.Update(
+				100,
+				# Translators: The download has finished; closing this dialog continues the add-on installation.
+				_("Download complete. You can now close this dialog to continue installing the update."),
+			)
 			progress.Destroy()
 
 			progress = wx.ProgressDialog(


### PR DESCRIPTION
## Summary

- Rename the dictionary update button to describe its action.
- Keep download progress at 99% until the downloaded file is closed.
- Explain that closing the completed-download dialog continues installation.

## Testing

- Not run (the dictionary update UI and download flow were not exercised).